### PR TITLE
Prevent cursor being shown during mouse selection

### DIFF
--- a/packages/board/src/svelte/CursorRender.svelte
+++ b/packages/board/src/svelte/CursorRender.svelte
@@ -12,9 +12,11 @@
     const fill = "#08f";
     const cursorSize = 0.2;
 
-    const dCursor = derived(ref, cursorIdx => {
-        if (null == cursorIdx) return '';
-        const [ x, y ] = cellIdx2cellCoord(cursorIdx, grid);
+    const dCursor = derived(ref, cursorState => {
+        const { index, isShown } = cursorState;
+
+        if (!isShown) return '';
+        const [ x, y ] = cellIdx2cellCoord(index, grid);
         return `M${x},${y}L${x + cursorSize},${y}L${x},${y + cursorSize}Z`;
     });
 </script>

--- a/packages/web/src/js/element/arrow.ts
+++ b/packages/web/src/js/element/arrow.ts
@@ -4,7 +4,7 @@ import { arrayObj2array, boardRepr, cellCoord2CellIdx, cellIdx2cellCoord } from 
 import { pushHistory } from "../history";
 import { AdjacentCellPointerHandler, CellDragTapEvent } from "../input/adjacentCellPointerHandler";
 import type { InputHandler } from "../input/inputHandler";
-import { userCursorState, userSelectState } from "../user";
+import { userCursorIsShownState, userSelectState } from "../user";
 import type { ElementInfo } from "./element";
 
 export const arrowInfo: ElementInfo = {
@@ -216,7 +216,7 @@ export function getArrowInputHandler(stateRef: StateRef, grid: Grid, svg: SVGSVG
         load(): void {
             // TODO: not really that great of a way of doing this.
             userSelectState.replace(null);
-            userCursorState.replace(null);
+            userCursorIsShownState.replace(false);
         },
         unload(): void {
             pointerHandler.up();

--- a/packages/web/src/js/element/clone.ts
+++ b/packages/web/src/js/element/clone.ts
@@ -4,7 +4,7 @@ import { AdjacentCellPointerHandler, CellDragTapEvent } from "../input/adjacentC
 import type { InputHandler } from "../input/inputHandler";
 import { parseDigit } from "../input/inputHandler";
 import { arrayObj2array, boardRepr, cellCoord2CellIdx, cellIdx2cellCoord, warnClones } from "@sudoku-studio/board-utils";
-import { userCursorState, userSelectState } from "../user";
+import { userCursorIsShownState, userSelectState } from "../user";
 import type { ElementInfo } from "./element";
 import { pushHistory } from "../history";
 import { hsluvToHex } from "hsluv";
@@ -231,7 +231,7 @@ function getInputHandler(stateRef: StateRef, grid: Grid, svg: SVGSVGElement): In
         load(): void {
             // TODO: not really that great of a way of doing this.
             userSelectState.replace(null);
-            userCursorState.replace(null);
+            userCursorIsShownState.replace(false);
         },
         unload(): void {
             pointerHandler.up();

--- a/packages/web/src/js/element/killer.ts
+++ b/packages/web/src/js/element/killer.ts
@@ -4,7 +4,7 @@ import { AdjacentCellPointerHandler, CellDragTapEvent } from "../input/adjacentC
 import type { InputHandler } from "../input/inputHandler";
 import { parseDigit } from "../input/inputHandler";
 import { boardRepr, cellCoord2CellIdx, idxMapToKeysArray, warnSum, writeRepeatingDigits } from "@sudoku-studio/board-utils";
-import { userCursorState, userSelectState } from "../user";
+import { userCursorIsShownState, userSelectState } from "../user";
 import type { ElementInfo } from "./element";
 import { pushHistory } from "../history";
 
@@ -134,7 +134,7 @@ function getInputHandler(stateRef: StateRef, grid: Grid, svg: SVGSVGElement): In
         load(): void {
             // TODO: not really that great of a way of doing this.
             userSelectState.replace(null);
-            userCursorState.replace(null);
+            userCursorIsShownState.replace(false);
         },
         unload(): void {
             pointerHandler.up();

--- a/packages/web/src/js/element/positionNumbers.ts
+++ b/packages/web/src/js/element/positionNumbers.ts
@@ -2,7 +2,7 @@ import type { Coord, Geometry, Grid, Idx, IdxBitset, IdxMap, schema } from "@sud
 import type { StateRef } from "@sudoku-studio/state-manager";
 import { cellCoord2CellIdx, click2svgCoord, diagonalIdx2diagonalCellCoords, edgeIdx2cellIdxes, seriesIdx2CellCoords, svgCoord2diagonalIdx, svgCoord2edgeIdx, svgCoord2seriesIdx, warnSum } from "@sudoku-studio/board-utils";
 import { InputHandler, parseDigit } from "../input/inputHandler";
-import { userCursorState, userSelectState } from "../user";
+import { userCursorIsShownState, userSelectState } from "../user";
 import type { ElementInfo } from "./element";
 import { pushHistory } from "../history";
 
@@ -318,7 +318,7 @@ function getInputHandler<TAG extends Geometry>(ref: StateRef, grid: Grid, svg: S
         load(): void {
             // TODO: not really that great of a way of doing this.
             userSelectState.replace(null);
-            userCursorState.replace(null);
+            userCursorIsShownState.replace(false);
         },
         unload(): void {
         },

--- a/packages/web/src/js/element/quadruple.ts
+++ b/packages/web/src/js/element/quadruple.ts
@@ -2,7 +2,7 @@ import type { ArrayObj, Geometry, Grid, IdxBitset, IdxMap, schema } from "@sudok
 import type { StateRef } from "@sudoku-studio/state-manager";
 import { arrayObj2array, cellCoord2CellIdx, click2svgCoord, cornerCoord2cellCoords, cornerCoord2cornerIdx, cornerIdx2cornerCoord, svgCoord2cornerCoord } from "@sudoku-studio/board-utils";
 import { InputHandler, parseDigit } from "../input/inputHandler";
-import { userCursorState, userSelectState } from "../user";
+import { userCursorIsShownState, userSelectState } from "../user";
 import type { ElementInfo } from "./element";
 import { pushHistory } from "../history";
 
@@ -80,7 +80,7 @@ function getInputHandler(ref: StateRef, grid: Grid, svg: SVGSVGElement): InputHa
         load(): void {
             // TODO: not really that great of a way of doing this.
             userSelectState.replace(null);
-            userCursorState.replace(null);
+            userCursorIsShownState.replace(false);
         },
         unload(): void {
         },

--- a/packages/web/src/js/element/region.ts
+++ b/packages/web/src/js/element/region.ts
@@ -4,7 +4,7 @@ import { AdjacentCellPointerHandler, CellDragTapEvent } from "../input/adjacentC
 import type { InputHandler } from "../input/inputHandler";
 import { cellCoord2CellIdx, getBorderCellPairs, idxMapToKeysArray } from "@sudoku-studio/board-utils";
 import { pushHistory } from "../history";
-import { userCursorState, userSelectState } from "../user";
+import { userCursorIsShownState, userSelectState } from "../user";
 import type { ElementInfo } from "./element";
 import { markDigitsFailingCondition } from "@sudoku-studio/board-utils";
 
@@ -154,7 +154,7 @@ function getInputHandler(stateRef: StateRef, grid: Grid, svg: SVGSVGElement): In
         load(): void {
             // TODO: not really that great of a way of doing this.
             userSelectState.replace(null);
-            userCursorState.replace(null);
+            userCursorIsShownState.replace(false);
         },
         unload(): void {
             pointerHandler.up();

--- a/packages/web/src/js/input/lineInputHandler.ts
+++ b/packages/web/src/js/input/lineInputHandler.ts
@@ -2,7 +2,7 @@ import { arrayObj2array, boardRepr, cellCoord2CellIdx } from "@sudoku-studio/boa
 import type { ArrayObj, Geometry, Grid, Idx } from "@sudoku-studio/schema";
 import type { Diff, StateRef } from "@sudoku-studio/state-manager";
 import { pushHistory } from "../history";
-import { userSelectState, userCursorState } from "../user";
+import { userCursorIsShownState, userSelectState } from "../user";
 import { AdjacentCellPointerHandler, CellDragTapEvent } from "./adjacentCellPointerHandler";
 import type { InputHandler } from "./inputHandler";
 
@@ -92,7 +92,7 @@ export function getLineInputHandler(stateRef: StateRef, grid: Grid, svg: SVGSVGE
         load(): void {
             // TODO: not really that great of a way of doing this.
             userSelectState.replace(null);
-            userCursorState.replace(null);
+            userCursorIsShownState.replace(false);
         },
         unload(): void {
             pointerHandler.up();

--- a/packages/web/src/js/user.ts
+++ b/packages/web/src/js/user.ts
@@ -7,7 +7,10 @@ export const MARK_TYPES = [
 export const userState = (window as any).userState = new StateManager();
 userState.update({
     select: {},
-    cursor: null,
+    cursor: {
+        index: null,
+        isShown: false,
+    },
 
     tool: '120', // TODO magic numbers.
     prevTool: '120',
@@ -22,7 +25,8 @@ userState.update({
 });
 
 export const userSelectState = userState.ref('select');
-export const userCursorState = userState.ref('cursor');
+export const userCursorIndexState = userState.ref('cursor', 'index');
+export const userCursorIsShownState = userState.ref('cursor', 'isShown');
 
 export const userPrevToolState = userState.ref('prevTool');
 export const userToolState = userState.ref('tool');

--- a/packages/web/src/svelte/entry/ButtonPad.svelte
+++ b/packages/web/src/svelte/entry/ButtonPad.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { TOOL_INPUT_NAME, userToolState, userState, userPrevToolState, userSelectState, userCursorState } from "../../js/user";
+    import { TOOL_INPUT_NAME, userToolState, userState, userPrevToolState, userSelectState, userCursorIsShownState } from "../../js/user";
     import { currentInputHandler } from "../../js/elementStores";
 
     // Button ripples.
@@ -31,7 +31,7 @@
     function saveImage(): void {
         // Clear selection.
         userSelectState.replace(null);
-        userCursorState.replace(null);
+        userCursorIsShownState.replace(false);
 
         const title  = boardState.get<string>('meta', 'title')  || 'Untitled';
         const author = boardState.get<string>('meta', 'author') || 'Anonymous';


### PR DESCRIPTION
Fixes #39 and fixes #15. This PR separates the cursor state into two properties - the `index` and whether the cursor `isShown`. The index is updated for both keyboard and mouse selection events, while `isShown` is only set to `true` during keyboard selection events.