### PR TITLE
Fix issues with deselection and constraint removal

### DIFF
--- a/packages/web/src/js/element/arrow.ts
+++ b/packages/web/src/js/element/arrow.ts
@@ -158,8 +158,9 @@ export function getArrowInputHandler(stateRef: StateRef, grid: Grid, svg: SVGSVG
         arrowRef.ref(mode).replace(minLength <= lineCells.length ? lineCells : null);
     }
 
-    pointerHandler.onDragStart = (_event: MouseEvent) => {
+    pointerHandler.onDragStart = (event: CellDragTapEvent) => {
         mode = Mode.DYNAMIC;
+        handle(event);
     };
 
     pointerHandler.onDrag = (event: CellDragTapEvent) => {
@@ -167,7 +168,6 @@ export function getArrowInputHandler(stateRef: StateRef, grid: Grid, svg: SVGSVG
     };
 
     pointerHandler.onDragEnd = () => {
-        if (Mode.DYNAMIC === mode) return;
         if (null == arrowRef) throw 'UNREACHABLE';
 
         if (0 >= bulbCells.length || 1 === bodyCells.length) {
@@ -189,7 +189,8 @@ export function getArrowInputHandler(stateRef: StateRef, grid: Grid, svg: SVGSVG
     };
 
     pointerHandler.onTap = (event: CellDragTapEvent) => {
-        if (Mode.DYNAMIC !== mode) return;
+        if (Mode.BODY !== mode) return;
+        // If we are in the arrow body mode but haven't dragged to a different cell, delete the arrow
 
         const { coord, grid } = event;
         const idx = cellCoord2CellIdx(coord, grid);
@@ -206,9 +207,6 @@ export function getArrowInputHandler(stateRef: StateRef, grid: Grid, svg: SVGSVG
         }
         if (null != arrowIdToDelete) {
             pushHistory(stateRef.ref(`${arrowIdToDelete}`).replace(null));
-        }
-        else {
-            handle(event);
         }
     };
 
@@ -233,7 +231,7 @@ export function getArrowInputHandler(stateRef: StateRef, grid: Grid, svg: SVGSVG
         },
 
         down(event: MouseEvent): void {
-            pointerHandler.down(event);
+            pointerHandler.down(event, grid, svg);
         },
         move(event: MouseEvent): void {
             pointerHandler.move(event, grid, svg);

--- a/packages/web/src/js/element/clone.ts
+++ b/packages/web/src/js/element/clone.ts
@@ -149,13 +149,7 @@ function getInputHandler(stateRef: StateRef, grid: Grid, svg: SVGSVGElement): In
         undo: {},
     };
 
-    pointerHandler.onDragStart = (_event: MouseEvent) => {
-        mode = Mode.DYNAMIC;
-        moveStart = null;
-        cloneRef = null;
-    };
-
-    pointerHandler.onDrag = (event: CellDragTapEvent) => {
+    function handle(event: CellDragTapEvent) {
         const { coord, grid } = event;
         const idx = cellCoord2CellIdx(coord, grid);
 
@@ -203,6 +197,18 @@ function getInputHandler(stateRef: StateRef, grid: Grid, svg: SVGSVGElement): In
 
         const diff = cloneRef.replace(cloneEntry);
         pushHistory(diff);
+    }
+
+    pointerHandler.onDragStart = (event: CellDragTapEvent) => {
+        mode = Mode.DYNAMIC;
+        moveStart = null;
+        cloneRef = null;
+
+        handle(event);
+    };
+
+    pointerHandler.onDrag = (event: CellDragTapEvent) => {
+        handle(event);
     };
 
     pointerHandler.onDragEnd = () => {
@@ -212,8 +218,8 @@ function getInputHandler(stateRef: StateRef, grid: Grid, svg: SVGSVGElement): In
     };
 
     pointerHandler.onTap = (event: CellDragTapEvent) => {
-        // Ensure this is a tap and not a drag.
-        if (Mode.DYNAMIC !== mode) return;
+        if (Mode.MOVING !== mode) return;
+        // If we are in the clone moving mode but haven't dragged to a different cell, delete the clone
 
         const { coord, grid } = event;
         const idx = cellCoord2CellIdx(coord, grid);
@@ -256,7 +262,7 @@ function getInputHandler(stateRef: StateRef, grid: Grid, svg: SVGSVGElement): In
         },
 
         down(event: MouseEvent): void {
-            pointerHandler.down(event);
+            pointerHandler.down(event, grid, svg);
         },
         move(event: MouseEvent): void {
             pointerHandler.move(event, grid, svg);

--- a/packages/web/src/js/input/adjacentCellPointerHandler.ts
+++ b/packages/web/src/js/input/adjacentCellPointerHandler.ts
@@ -10,7 +10,7 @@ export type CellDragTapEvent = {
 export class AdjacentCellPointerHandler {
     onTap: null | ((event: CellDragTapEvent) => void) = null;
     onDrag: null | ((event: CellDragTapEvent) => void) = null;
-    onDragStart: null | ((event: MouseEvent) => void) = null;
+    onDragStart: null | ((event: CellDragTapEvent) => void) = null;
     onDragEnd: null | (() => void) = null;
 
     private readonly _interpolateOnReender: boolean;
@@ -24,10 +24,10 @@ export class AdjacentCellPointerHandler {
         this._interpolateOnReender = interpolateOnReenter;
     }
 
-    down(event: MouseEvent): void {
-        this.onDragStart && this.onDragStart(event);
+    down(event: MouseEvent, grid: Grid, svg: SVGSVGElement): void {
         this._isDown = true;
         this._isTap = true;
+        this._handle(event, grid, svg);
     }
 
     move(event: MouseEvent, grid: Grid, svg: SVGSVGElement) {
@@ -78,14 +78,27 @@ export class AdjacentCellPointerHandler {
             const isFirstClick = null == this._prevPos;
             const coord = svgCoord2cellCoord(pos, grid, !isFirstClick);
             if (null != coord) {
-                if (this._prevCell !== cellCoord2CellIdx(coord, grid)) {
-                    if (null != this._prevCell)
-                        this._isTap = false; // Cancel tap as soon as moved one cell.
-
-                    this.onDrag && this.onDrag({ event, coord, grid });
-                    this._prevCell = cellCoord2CellIdx(coord, grid);
-                }
                 this._prevPos = pos;
+                const currentCellIndex = cellCoord2CellIdx(coord, grid);
+
+                if (null != this._prevCell) {
+                    // Ignore a drag within the same cell as the previous cell
+                    if (this._prevCell === currentCellIndex) {
+                        return;
+                    }
+
+                    // Cancel any active tap since we have moved between cells
+                    this._isTap = false;
+
+                    // Trigger drag event for the cell where the mouse is
+                    this.onDrag && this.onDrag({ event, coord, grid });
+                } else if (this._isTap) {
+                    // Trigger drag start event at start of click
+                    this.onDragStart && this.onDragStart({ event, coord, grid });
+                }
+
+                // Update previous cell to the cell where the mouse is
+                this._prevCell = currentCellIndex;
             }
             // Otherwise otherwise reset prevPos if pointer's off the grid.
             else if (!(this._interpolateOnReender || isOnGrid(pos, grid))) {

--- a/packages/web/src/js/input/lineInputHandler.ts
+++ b/packages/web/src/js/input/lineInputHandler.ts
@@ -20,12 +20,7 @@ export function getLineInputHandler(stateRef: StateRef, grid: Grid, svg: SVGSVGE
     let lineRef: null | StateRef = null;
     const lineCells: Idx<Geometry.CELL>[] = [];
 
-    pointerHandler.onDragStart = (_event: MouseEvent) => {
-        lineCells.length = 0;
-        lineRef = stateRef.ref(boardRepr.makeUid());
-    };
-
-    pointerHandler.onDrag = (event: CellDragTapEvent) => {
+    function handle(event: CellDragTapEvent) {
         if (null == lineRef) throw 'UNREACHABLE';
 
         const { coord, grid } = event;
@@ -40,6 +35,17 @@ export function getLineInputHandler(stateRef: StateRef, grid: Grid, svg: SVGSVGE
         }
 
         lineRef.replace(1 < lineCells.length ? lineCells : null);
+    }
+
+    pointerHandler.onDragStart = (event: CellDragTapEvent) => {
+        lineCells.length = 0;
+        lineRef = stateRef.ref(boardRepr.makeUid());
+
+        handle(event);
+    };
+
+    pointerHandler.onDrag = (event: CellDragTapEvent) => {
+        handle(event);
     };
 
     pointerHandler.onDragEnd = () => {
@@ -109,7 +115,7 @@ export function getLineInputHandler(stateRef: StateRef, grid: Grid, svg: SVGSVGE
         },
 
         down(event: MouseEvent): void {
-            pointerHandler.down(event);
+            pointerHandler.down(event, grid, svg);
         },
         move(event: MouseEvent): void {
             pointerHandler.move(event, grid, svg);


### PR DESCRIPTION
This pull request resolves an issue with the input handlers, which could be reproduced with the following steps:
1. Select a cell.
2. Click on the same cell and hold down the mouse button.
3. Move the cursor by a few pixels, but stay within the same cell.
4. Release the cursor.

These steps resulted in the cell not being deselected. The same issue applied to removing arrows, killer cages, and clones.