### PR TITLE
Always run CI/CD workflow on dev branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
   test:
     name: Test
     needs: pre_job
-    if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
+    if: ${{ github.ref == 'refs/heads/dev' || needs.pre_job.outputs.should_skip != 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:


### PR DESCRIPTION
The most recent commit on the `dev` branch was not deployed to GitHub Pages: https://github.com/SudokuStudio/SudokuStudio/actions/runs/1765392778

This is because the `test` workflow already ran on the pull request (without deploying to GitHub Pages), and the `skip-duplicate-actions` step determined that the same set of files were already tested. However, since the `dev` branch has the additional step of deploying, this causes a problem.

This PR updates the `test` workflow so that it always runs on the `dev` branch.