### PR TITLE
Update modal for adding constraint

### DIFF
--- a/packages/web/src/js/elements.ts
+++ b/packages/web/src/js/elements.ts
@@ -102,5 +102,13 @@ const elementsFuse = new Fuse(searchableElements, {
 });
 
 export function search(fuzzyPattern: string) {
+    if (!fuzzyPattern) {
+        // If no search text, show all constraints
+        return searchableElements.map((item, refIndex) => ({
+            item,
+            score: 1,
+            refIndex,
+        }));
+    }
     return elementsFuse.search(fuzzyPattern);
 }

--- a/packages/web/src/svelte/edit/constraint/CheckboxMenuComponent.svelte
+++ b/packages/web/src/svelte/edit/constraint/CheckboxMenuComponent.svelte
@@ -29,6 +29,24 @@
         }
     }
 
+    function initializeAsEnabled() {
+        if (!Array.isArray(info.checkbox)) {
+            valueRef.replace(true);
+        }
+        else {
+            const dict: Record<string, boolean> = {};
+            for (const { refPath } of info.checkbox) {
+                dict[refPath] = true;
+            }
+            valueRef.replace(dict);
+        }
+    }
+
+    if (null == valueRef.get()) {
+        // Initialize constraint as enabled when first added
+        initializeAsEnabled();
+    }
+
     function unused(data: any): boolean { // TODO? Do this somewhere else?
         if (!Array.isArray(info.checkbox)) {
             return !data;


### PR DESCRIPTION
This pull request makes two changes:
- Global constraints now default to enabled when they are first added.
- When clicking the "Add" button, the full list of constraints is shown if the search text is empty.