### PR TITLE
refactor: update state, `ElementInfo` to track types

### DIFF
--- a/packages/board/src/lib/Board.svelte
+++ b/packages/board/src/lib/Board.svelte
@@ -1,6 +1,6 @@
 <script lang="ts" context="module">
     import type { Component, ComponentInternals, ComponentProps } from 'svelte';
-    import type { Geometry, Grid, Idx, schema } from '@sudoku-studio/schema';
+    import type { Geometry, Grid, Idx, schema, user } from '@sudoku-studio/schema';
     import type { StateManager, StateRef } from '@sudoku-studio/state-manager/src';
 
     import { derived, readable } from 'svelte/store';
@@ -268,7 +268,7 @@
 </script>
 
 <script lang="ts">
-    export let userState: undefined | null | StateManager;
+    export let userState: undefined | null | StateManager<user.UserState>;
     export let warningState: undefined | null | StateManager;
     export let boardState: StateManager;
     export let svg: SVGSVGElement = null!;
@@ -325,7 +325,7 @@
             });
         }
 
-        boardState.ref('elements/*').watch<schema.Element>(([_elements, elementId], oldVal, newVal) => {
+        boardState.ref<schema.Element>('elements/*').watch(([_elements, elementId], oldVal, newVal) => {
             const type = oldVal?.type || newVal?.type;
 
             // Element has been deleted via undo/redo

--- a/packages/schema/schema.d.ts
+++ b/packages/schema/schema.d.ts
@@ -73,7 +73,6 @@ export declare namespace schema {
         | ConsecutiveElement
         | DiagonalElement
         | KillerElement
-        | KillerElement
         | CloneElement
         | QuadrupleElement
         | LineElement
@@ -114,7 +113,7 @@ export declare namespace schema {
 
     export interface BooleanElement extends AbstractElement {
         type: 'knight' | 'king' | 'disjointGroups' | 'antiX' | 'antiV' | 'selfTaxicab';
-        value?: { positive: boolean; negative: boolean };
+        value?: boolean;
     }
     export interface ConsecutiveElement extends AbstractElement {
         type: 'consecutive';
@@ -188,6 +187,18 @@ export declare namespace schema {
     export interface TODO_ELEMENTS extends AbstractElement {
         type: never;
         value?: unknown;
+    }
+}
+
+export declare namespace user {
+    export interface UserState {
+        select: IdxBitset<Geometry.CELL>;
+        cursor: { index: Idx<Geometry.CELL> | null; isShown: boolean };
+        tool: string;
+        prevTool: string;
+        marks: { filled: string; corner: string; center: string; colors: string };
+        history: unknown; // TODO
+        historyUndone: unknown; // TODO
     }
 }
 

--- a/packages/state-manager/src/state-manager.ts
+++ b/packages/state-manager/src/state-manager.ts
@@ -34,11 +34,11 @@ function undefToNull<T>(val: T): null | NonNullable<T> | null {
     return val!;
 }
 
-export class StateRef {
-    private readonly _stateManager: StateManager;
+export class StateRef<T extends Data = Data> {
+    private readonly _stateManager: StateManager<any>;
     private readonly _path: string[] = [];
 
-    constructor(stateManager: StateManager, path: string[]) {
+    constructor(stateManager: StateManager<any>, path: string[]) {
         this._stateManager = stateManager;
         for (const seg of path) {
             if ('..' === seg) this._path.pop();
@@ -51,24 +51,24 @@ export class StateRef {
         return [...this._path];
     }
 
-    ref(...path: string[]): StateRef {
+    ref<U extends Data = Data>(...path: string[]): StateRef<U> {
         return new StateRef(this._stateManager, [...this._path, ...path]);
     }
 
-    get<T extends Data>(): null | T {
-        return this._stateManager.get(...this._path);
+    get(): null | T {
+        return this._stateManager.get<T>(...this._path);
     }
 
-    watch<T extends Data>(watcher: Watcher<T>, triggerNow: boolean): Watcher<T> {
+    watch(watcher: Watcher<T>, triggerNow: boolean): Watcher<T> {
         this._stateManager.watch(watcher, triggerNow, this._path.join('/'));
         return watcher;
     }
 
-    unwatch<T extends Data>(watcher: Watcher<T>) {
+    unwatch(watcher: Watcher<T>) {
         this._stateManager.unwatch(watcher);
     }
 
-    replace(newData: Data): null | Diff {
+    replace(newData: null | T): null | Diff {
         return this._stateManager.update({ [this._path.join('/')]: newData });
     }
 
@@ -95,9 +95,9 @@ export class StateRef {
 /// undo/redo diff to the caller.
 ///
 /// This is where the magic happens.
-export class StateManager {
+export class StateManager<T extends Data = Data> {
     /// The data contained in and managed by this StateManager.
-    private _data: Data = null;
+    private _data: T | null = null;
 
     /// Map from each watcher to the paths it's watching.
     private readonly _watchers: Map<Watcher<any>, Set<string>> = new Map();
@@ -105,21 +105,21 @@ export class StateManager {
 
     constructor() {}
 
-    ref(...path: string[]): StateRef {
+    ref<U extends Data = Data>(...path: string[]): StateRef<U> {
         return new StateRef(this, path);
     }
 
-    get<T extends Data>(...path: string[]): T | null {
+    get<U>(...path: string[]): U | null {
         let target = this._data;
         for (const seg of path) {
             if (null == target) break;
             if (seg.includes('/')) throw Error('Path cannot contain "/", split into varargs.');
             target = (target as any)[seg];
         }
-        return undefToNull(target) as unknown as T | null;
+        return undefToNull(target) as unknown as U | null;
     }
 
-    watch<T extends Data>(watcher: Watcher<T>, triggerNow: boolean, ...patterns: [string, ...string[]]): Watcher<T> {
+    watch(watcher: Watcher<T>, triggerNow: boolean, ...patterns: [string, ...string[]]): Watcher<T> {
         let patternSet = this._watchers.get(watcher);
         if (null == patternSet) {
             patternSet = new Set();
@@ -132,7 +132,7 @@ export class StateManager {
         return watcher;
     }
 
-    unwatch<T extends Data>(watcher: Watcher<T>): void {
+    unwatch(watcher: Watcher<T>): void {
         if (!this._watchers.has(watcher)) throw Error('Cannot find watcher.');
 
         const patterns = this._watchers.get(watcher)!;
@@ -162,7 +162,7 @@ export class StateManager {
             if (!isEq(this._data, newData)) {
                 changed = true;
 
-                this._data = newData;
+                this._data = newData as any;
                 redo.push(...newRedo);
                 undo.push(...newUndo);
             }

--- a/packages/web/src/lib/js/board.ts
+++ b/packages/web/src/lib/js/board.ts
@@ -1,5 +1,5 @@
 import { browser } from '$app/environment';
-import type { Geometry, Idx, IdxMap, schema } from '@sudoku-studio/schema';
+import type { Geometry, Grid, Idx, IdxMap, schema } from '@sudoku-studio/schema';
 import type { Data, Diff } from '@sudoku-studio/state-manager/src';
 import { StateManager } from '@sudoku-studio/state-manager/src';
 import { getDigits as getDigitsHelper } from '@sudoku-studio/board-utils/src';
@@ -13,7 +13,7 @@ if (browser) {
     (window as any).boardState = boardState;
 }
 
-export const boardGridRef = boardState.ref('grid');
+export const boardGridRef = boardState.ref<Grid>('grid');
 
 function getElements(): Record<string, schema.Element> | null {
     return boardState.get<schema.Board['elements']>('elements');

--- a/packages/web/src/lib/js/element/arrow.ts
+++ b/packages/web/src/lib/js/element/arrow.ts
@@ -8,7 +8,7 @@ import type { InputHandler } from '../input/inputHandler';
 import { userCursorIsShownState, userSelectState } from '../user';
 import type { ElementInfo } from './element';
 
-export const arrowInfo: ElementInfo = {
+export const arrowInfo: ElementInfo<schema.ArrowElement['value']> = {
     getInputHandler: getArrowInputHandler,
     order: 90,
     inGlobalMenu: false,
@@ -89,7 +89,11 @@ function reorderArrowBulb(cells: Idx<Geometry.CELL>[], grid: Grid): void {
     cells.sort((a, b) => a - b);
 }
 
-export function getArrowInputHandler(stateRef: StateRef, grid: Grid, svg: SVGSVGElement): InputHandler {
+export function getArrowInputHandler(
+    stateRef: StateRef<schema.ArrowElement['value']>,
+    grid: Grid,
+    svg: SVGSVGElement,
+): InputHandler {
     const pointerHandler = new AdjacentCellPointerHandler(true);
 
     enum Mode {
@@ -104,7 +108,7 @@ export function getArrowInputHandler(stateRef: StateRef, grid: Grid, svg: SVGSVG
     let bodyCells: Idx<Geometry.CELL>[] = [];
 
     function handleDragStart(idx: Idx<Geometry.CELL>): void {
-        const existingArrows = stateRef.get<schema.ArrowElement['value']>() || {};
+        const existingArrows = stateRef.get() || {};
         for (const [arrowId, { bulb, body }] of Object.entries(existingArrows)) {
             const bulbArr = arrayObj2array(bulb || {});
             if (bulbArr.includes(idx)) {
@@ -188,7 +192,7 @@ export function getArrowInputHandler(stateRef: StateRef, grid: Grid, svg: SVGSVG
         const idx = cellCoord2CellIdx(coord, grid);
 
         let arrowIdToDelete: null | string = null;
-        for (const [arrowId, { bulb }] of Object.entries(stateRef.get<schema.ArrowElement['value']>() || {})) {
+        for (const [arrowId, { bulb }] of Object.entries(stateRef.get() || {})) {
             if (arrayObj2array(bulb || {}).includes(idx)) {
                 arrowIdToDelete = arrowId;
                 break;

--- a/packages/web/src/lib/js/element/basic.ts
+++ b/packages/web/src/lib/js/element/basic.ts
@@ -8,7 +8,7 @@ import {
 } from '@sudoku-studio/board-utils/src';
 import type { ElementInfo } from './element';
 
-export const gridInfo: ElementInfo = {
+export const gridInfo: ElementInfo<undefined> = {
     order: 101,
     permanent: true,
 
@@ -28,7 +28,7 @@ export const gridInfo: ElementInfo = {
     },
 } as const;
 
-export const gridRegionInfo: ElementInfo = {
+export const gridRegionInfo: ElementInfo<schema.GridRegionElement['value']> = {
     order: 100,
     permanent: true,
 

--- a/packages/web/src/lib/js/element/clone.ts
+++ b/packages/web/src/lib/js/element/clone.ts
@@ -17,7 +17,7 @@ import { pushHistory } from '../history';
 import * as hsluv from 'hsluv';
 import { makeA1Column } from '../util';
 
-export const cloneInfo: ElementInfo = {
+export const cloneInfo: ElementInfo<schema.CloneElement['value']> = {
     getInputHandler,
     order: 10,
     inGlobalMenu: false,
@@ -45,10 +45,14 @@ export const cloneInfo: ElementInfo = {
     },
 };
 
-function getInputHandler(stateRef: StateRef, grid: Grid, svg: SVGSVGElement): InputHandler {
+function getInputHandler(
+    stateRef: StateRef<schema.CloneElement['value']>,
+    grid: Grid,
+    svg: SVGSVGElement,
+): InputHandler {
     const pointerHandler = new AdjacentCellPointerHandler(true);
 
-    let cloneRef: null | StateRef = null;
+    let cloneRef: null | StateRef<typeof cloneEntry> = null;
     let moveStart: null | Coord<Geometry.CELL> = null;
     let cloneEntry = {
         label: null as null | string,
@@ -73,7 +77,7 @@ function getInputHandler(stateRef: StateRef, grid: Grid, svg: SVGSVGElement): In
         let digit = parseDigit(code);
         if (undefined === digit) return false;
 
-        const oldVal = cloneRef.ref('sum').get<true | number>();
+        const oldVal = cloneRef.ref<true | number>('sum').get();
         if (null != digit && 'number' === typeof oldVal) {
             const multiDigit = oldVal * 10 + digit;
             if (multiDigit < max) digit = multiDigit;
@@ -83,7 +87,7 @@ function getInputHandler(stateRef: StateRef, grid: Grid, svg: SVGSVGElement): In
     }
 
     function getExistingCloneAtIdx(idx: Idx<Geometry.CELL>): null | [string, 'a' | 'b'] {
-        for (const [cloneId, { a, b }] of Object.entries(stateRef.get<schema.CloneElement['value']>() || {})) {
+        for (const [cloneId, { a, b }] of Object.entries(stateRef.get() || {})) {
             if (arrayObj2array(a || {}).includes(idx)) {
                 return [cloneId, 'a'];
             }
@@ -96,7 +100,7 @@ function getInputHandler(stateRef: StateRef, grid: Grid, svg: SVGSVGElement): In
 
     function makeNewClone(): typeof cloneEntry {
         const existingLabels = new Set();
-        for (const { label } of Object.values(stateRef.get<schema.CloneElement['value']>() || {})) {
+        for (const { label } of Object.values(stateRef.get() || {})) {
             if (null != label) existingLabels.add(label);
         }
         for (let i = 0; ; i++) {
@@ -113,9 +117,9 @@ function getInputHandler(stateRef: StateRef, grid: Grid, svg: SVGSVGElement): In
             const [cloneId, clickedAB] = existingClone;
             const unclickedAB = 'a' === clickedAB ? 'b' : 'a';
 
-            cloneRef = stateRef.ref(cloneId);
+            cloneRef = stateRef.ref<typeof cloneEntry>(cloneId);
             mode = Mode.MOVING;
-            cloneEntry = Object.assign({}, cloneRef.get<typeof cloneEntry>());
+            cloneEntry = Object.assign({}, cloneRef.get());
 
             if (null != cloneEntry[unclickedAB]) {
                 const clickedArr = arrayObj2array(cloneEntry[clickedAB]);

--- a/packages/web/src/lib/js/element/digit.ts
+++ b/packages/web/src/lib/js/element/digit.ts
@@ -1,13 +1,13 @@
 import type { StateRef } from '@sudoku-studio/state-manager/src';
-import type { Grid } from '@sudoku-studio/schema';
+import type { Grid, schema } from '@sudoku-studio/schema';
 import type { InputHandler } from '../input/inputHandler';
 import { getSelectDigitInputHandler } from '../input/selectDigitInputHandler';
 import hsluv from 'hsluv';
 
 import type { ElementInfo } from './element';
 
-export const givensInfo: ElementInfo = {
-    getInputHandler(ref: StateRef, grid: Grid, svg: SVGSVGElement): InputHandler {
+export const givensInfo: ElementInfo<schema.DigitElement['value']> = {
+    getInputHandler(ref: StateRef<schema.DigitElement['value']>, grid: Grid, svg: SVGSVGElement): InputHandler {
         return getSelectDigitInputHandler(ref, grid, svg, {
             multipleDigits: false,
             blockedByGivens: false,
@@ -20,8 +20,8 @@ export const givensInfo: ElementInfo = {
     inGlobalMenu: false,
     menu: { type: 'select', name: 'Given', icon: 'given' },
 } as const;
-export const filledInfo: ElementInfo = {
-    getInputHandler(ref: StateRef, grid: Grid, svg: SVGSVGElement): InputHandler {
+export const filledInfo: ElementInfo<schema.DigitElement['value']> = {
+    getInputHandler(ref: StateRef<schema.DigitElement['value']>, grid: Grid, svg: SVGSVGElement): InputHandler {
         return getSelectDigitInputHandler(ref, grid, svg, {
             multipleDigits: false,
             blockedByGivens: true,
@@ -32,8 +32,8 @@ export const filledInfo: ElementInfo = {
     order: 210,
 } as const;
 
-export const cornerInfo: ElementInfo = {
-    getInputHandler(ref: StateRef, grid: Grid, svg: SVGSVGElement): InputHandler {
+export const cornerInfo: ElementInfo<schema.PencilMarksElement['value']> = {
+    getInputHandler(ref: StateRef<schema.PencilMarksElement['value']>, grid: Grid, svg: SVGSVGElement): InputHandler {
         return getSelectDigitInputHandler(ref, grid, svg, {
             multipleDigits: true,
             blockedByGivens: true,
@@ -43,8 +43,8 @@ export const cornerInfo: ElementInfo = {
     },
     order: 200,
 } as const;
-export const centerInfo: ElementInfo = {
-    getInputHandler(ref: StateRef, grid: Grid, svg: SVGSVGElement): InputHandler {
+export const centerInfo: ElementInfo<schema.PencilMarksElement['value']> = {
+    getInputHandler(ref: StateRef<schema.PencilMarksElement['value']>, grid: Grid, svg: SVGSVGElement): InputHandler {
         return getSelectDigitInputHandler(ref, grid, svg, {
             multipleDigits: true,
             blockedByGivens: true,
@@ -55,8 +55,8 @@ export const centerInfo: ElementInfo = {
     order: 200,
 } as const;
 
-export const colorsInfo: ElementInfo = {
-    getInputHandler(ref: StateRef, grid: Grid, svg: SVGSVGElement): InputHandler {
+export const colorsInfo: ElementInfo<schema.ColorsElement['value']> = {
+    getInputHandler(ref: StateRef<schema.ColorsElement['value']>, grid: Grid, svg: SVGSVGElement): InputHandler {
         return getSelectDigitInputHandler(ref, grid, svg, {
             multipleDigits: true,
             blockedByGivens: false,

--- a/packages/web/src/lib/js/element/element.d.ts
+++ b/packages/web/src/lib/js/element/element.d.ts
@@ -1,5 +1,5 @@
 import type { SvelteComponent } from 'svelte';
-import type { Geometry, Idx, IdxBitset, IdxMap } from '@sudoku-studio/schema';
+import type { Geometry, Idx, IdxBitset, IdxMap, schema } from '@sudoku-studio/schema';
 import type { StateRef } from '@sudoku-studio/state-manager/src';
 import type { PointerHandler } from './pointerHandler';
 import type { InputHandler } from '../input/inputHandler';
@@ -21,8 +21,8 @@ export interface CheckboxMenuComponent extends AbstractMenuComponent {
 
 export type MenuComponent = SelectMenuComponent | CheckboxMenuComponent;
 
-export type ElementInfo = {
-    getInputHandler?: null | ((ref: StateRef, grid: Grid, svg: SVGSVGElement) => InputHandler);
+export type ElementInfo<V> = {
+    getInputHandler?: null | ((ref: StateRef<V>, grid: Grid, svg: SVGSVGElement) => InputHandler);
 
     /** Render order. */
     order: number;
@@ -36,7 +36,7 @@ export type ElementInfo = {
     getWarnings?:
         | null
         | ((
-              value: any,
+              value: V,
               grid: Grid,
               regionMap: IdxMap<Geometry.CELL, number>,
               digits: IdxMap<Geometry.CELL, number>,

--- a/packages/web/src/lib/js/element/killer.ts
+++ b/packages/web/src/lib/js/element/killer.ts
@@ -15,7 +15,7 @@ import { userCursorIsShownState, userSelectState } from '../user';
 import type { ElementInfo } from './element';
 import { pushHistory } from '../history';
 
-export const killerInfo: ElementInfo = {
+export const killerInfo: ElementInfo<schema.KillerElement['value']> = {
     getInputHandler,
     order: 120,
     inGlobalMenu: false,
@@ -42,10 +42,14 @@ export const killerInfo: ElementInfo = {
     },
 };
 
-function getInputHandler(stateRef: StateRef, grid: Grid, svg: SVGSVGElement): InputHandler {
+function getInputHandler(
+    stateRef: StateRef<schema.KillerElement['value']>,
+    grid: Grid,
+    svg: SVGSVGElement,
+): InputHandler {
     const pointerHandler = new AdjacentCellPointerHandler(false);
 
-    let cageRef: null | StateRef = null;
+    let cageRef: null | StateRef<{ sum?: number; cells: IdxBitset<Geometry.CELL> }> = null;
 
     enum Mode {
         DYNAMIC,
@@ -61,7 +65,7 @@ function getInputHandler(stateRef: StateRef, grid: Grid, svg: SVGSVGElement): In
         let digit = parseDigit(code);
         if (undefined === digit) return false;
 
-        const oldVal = cageRef.ref('sum').get<true | number>();
+        const oldVal = cageRef.ref<true | number>('sum').get();
         if (null != digit && 'number' === typeof oldVal) {
             const multiDigit = oldVal * 10 + digit;
             if (multiDigit < max) digit = multiDigit;
@@ -72,14 +76,14 @@ function getInputHandler(stateRef: StateRef, grid: Grid, svg: SVGSVGElement): In
             const diff = cageRef.replace(null);
             pushHistory(diff);
         } else {
-            const diff = cageRef.ref('sum').replace(digit);
+            const diff = cageRef.ref<number>('sum').replace(digit);
             pushHistory(diff);
         }
         return true;
     }
 
     function getExistingCageAtIdx(idx: Idx<Geometry.CELL>): null | string {
-        for (const [cageId, { sum: _, cells }] of Object.entries(stateRef.get<schema.KillerElement['value']>() || {})) {
+        for (const [cageId, { sum: _, cells }] of Object.entries(stateRef.get() || {})) {
             if (cells[idx]) {
                 return cageId;
             }

--- a/packages/web/src/lib/js/element/lines.ts
+++ b/packages/web/src/lib/js/element/lines.ts
@@ -1,12 +1,12 @@
-import type { Geometry, Grid, IdxBitset, IdxMap, schema } from '@sudoku-studio/schema';
+import type { ArrayObj, Geometry, Grid, Idx, IdxBitset, IdxMap, schema } from '@sudoku-studio/schema';
 import type { StateRef } from '@sudoku-studio/state-manager/src';
 import type { InputHandler } from '../input/inputHandler';
 import type { ElementInfo } from './element';
 import { getLineInputHandler } from '../input/lineInputHandler';
 import { arrayObj2array, warnClones } from '@sudoku-studio/board-utils/src';
 
-export const thermoInfo: ElementInfo = {
-    getInputHandler(ref: StateRef, grid: Grid, svg: SVGSVGElement): InputHandler {
+export const thermoInfo: ElementInfo<schema.LineElement['value']> = {
+    getInputHandler(ref: StateRef<schema.LineElement['value']>, grid: Grid, svg: SVGSVGElement): InputHandler {
         return getLineInputHandler(ref, grid, svg, {
             deletePrioritizeHead: true,
             deletePrioritizeTail: false,
@@ -32,8 +32,8 @@ export const thermoInfo: ElementInfo = {
     },
 };
 
-export const slowThermoInfo: ElementInfo = {
-    getInputHandler(ref: StateRef, grid: Grid, svg: SVGSVGElement): InputHandler {
+export const slowThermoInfo: ElementInfo<schema.LineElement['value']> = {
+    getInputHandler(ref: StateRef<schema.LineElement['value']>, grid: Grid, svg: SVGSVGElement): InputHandler {
         return getLineInputHandler(ref, grid, svg, {
             deletePrioritizeHead: true,
             deletePrioritizeTail: false,
@@ -105,8 +105,8 @@ function getThermoWarnings(
     }
 }
 
-export const betweenInfo: ElementInfo = {
-    getInputHandler(ref: StateRef, grid: Grid, svg: SVGSVGElement): InputHandler {
+export const betweenInfo: ElementInfo<schema.LineElement['value']> = {
+    getInputHandler(ref: StateRef<schema.LineElement['value']>, grid: Grid, svg: SVGSVGElement): InputHandler {
         return getLineInputHandler(ref, grid, svg, {
             deletePrioritizeHead: true,
             deletePrioritizeTail: true,
@@ -155,8 +155,8 @@ export const betweenInfo: ElementInfo = {
     },
 };
 
-export const doubleArrowInfo: ElementInfo = {
-    getInputHandler(ref: StateRef, grid: Grid, svg: SVGSVGElement): InputHandler {
+export const doubleArrowInfo: ElementInfo<schema.LineElement['value']> = {
+    getInputHandler(ref: StateRef<schema.LineElement['value']>, grid: Grid, svg: SVGSVGElement): InputHandler {
         return getLineInputHandler(ref, grid, svg, {
             deletePrioritizeHead: true,
             deletePrioritizeTail: true,
@@ -210,8 +210,8 @@ export const doubleArrowInfo: ElementInfo = {
     },
 };
 
-export const lockoutInfo: ElementInfo = {
-    getInputHandler(ref: StateRef, grid: Grid, svg: SVGSVGElement): InputHandler {
+export const lockoutInfo: ElementInfo<schema.LineElement['value']> = {
+    getInputHandler(ref: StateRef<schema.LineElement['value']>, grid: Grid, svg: SVGSVGElement): InputHandler {
         return getLineInputHandler(ref, grid, svg, {
             deletePrioritizeHead: true,
             deletePrioritizeTail: true,
@@ -266,8 +266,8 @@ export const lockoutInfo: ElementInfo = {
     },
 };
 
-export const palindromeInfo: ElementInfo = {
-    getInputHandler(ref: StateRef, grid: Grid, svg: SVGSVGElement): InputHandler {
+export const palindromeInfo: ElementInfo<schema.LineElement['value']> = {
+    getInputHandler(ref: StateRef<schema.LineElement['value']>, grid: Grid, svg: SVGSVGElement): InputHandler {
         return getLineInputHandler(ref, grid, svg, {
             deletePrioritizeHead: false,
             deletePrioritizeTail: false,
@@ -307,9 +307,9 @@ function getWhisperInfo(
     icon: string,
     description: string,
     tags: string[],
-): ElementInfo {
+): ElementInfo<schema.LineElement['value']> {
     return {
-        getInputHandler(ref: StateRef, grid: Grid, svg: SVGSVGElement): InputHandler {
+        getInputHandler(ref: StateRef<schema.LineElement['value']>, grid: Grid, svg: SVGSVGElement): InputHandler {
             return getLineInputHandler(ref, grid, svg, {
                 deletePrioritizeHead: false,
                 deletePrioritizeTail: false,
@@ -351,7 +351,7 @@ function getWhisperInfo(
     };
 }
 
-export const germanWhisperInfo: ElementInfo = getWhisperInfo(
+export const germanWhisperInfo: ElementInfo<schema.LineElement['value']> = getWhisperInfo(
     (gridWidth) => (gridWidth + 1) >> 1,
     'German Whisper',
     'whisper',
@@ -359,7 +359,7 @@ export const germanWhisperInfo: ElementInfo = getWhisperInfo(
     ['line', 'german', 'five', '5'],
 );
 
-export const dutchWhisperInfo: ElementInfo = getWhisperInfo(
+export const dutchWhisperInfo: ElementInfo<schema.LineElement['value']> = getWhisperInfo(
     (gridWidth) => ((gridWidth + 1) >> 1) - 1,
     'Dutch Whisper',
     'dutch-whisper',
@@ -367,8 +367,8 @@ export const dutchWhisperInfo: ElementInfo = getWhisperInfo(
     ['line', 'dutch', 'five', '4'],
 );
 
-export const renbanInfo: ElementInfo = {
-    getInputHandler(ref: StateRef, grid: Grid, svg: SVGSVGElement): InputHandler {
+export const renbanInfo: ElementInfo<schema.LineElement['value']> = {
+    getInputHandler(ref: StateRef<schema.LineElement['value']>, grid: Grid, svg: SVGSVGElement): InputHandler {
         return getLineInputHandler(ref, grid, svg, {
             deletePrioritizeHead: false,
             deletePrioritizeTail: false,
@@ -413,8 +413,8 @@ export const renbanInfo: ElementInfo = {
     },
 };
 
-export const regionSumInfo: ElementInfo = {
-    getInputHandler(ref: StateRef, grid: Grid, svg: SVGSVGElement): InputHandler {
+export const regionSumInfo: ElementInfo<schema.LineElement['value']> = {
+    getInputHandler(ref: StateRef<schema.LineElement['value']>, grid: Grid, svg: SVGSVGElement): InputHandler {
         return getLineInputHandler(ref, grid, svg, {
             deletePrioritizeHead: false,
             deletePrioritizeTail: false,

--- a/packages/web/src/lib/js/element/positionNumbers.ts
+++ b/packages/web/src/lib/js/element/positionNumbers.ts
@@ -17,8 +17,8 @@ import { userCursorIsShownState, userSelectState } from '../user';
 import type { ElementInfo } from './element';
 import { pushHistory } from '../history';
 
-export const differenceInfo: ElementInfo = {
-    getInputHandler(ref: StateRef, grid: Grid, svg: SVGSVGElement): InputHandler {
+export const differenceInfo: ElementInfo<schema.EdgeNumberElement['value']> = {
+    getInputHandler(ref: StateRef<schema.EdgeNumberElement['value']>, grid: Grid, svg: SVGSVGElement): InputHandler {
         return getInputHandler(ref, grid, svg, { svgCoord2idx: svgCoord2edgeIdx, max: 10 });
     },
     order: 140,
@@ -53,8 +53,8 @@ export const differenceInfo: ElementInfo = {
     },
 };
 
-export const ratioInfo: ElementInfo = {
-    getInputHandler(ref: StateRef, grid: Grid, svg: SVGSVGElement): InputHandler {
+export const ratioInfo: ElementInfo<schema.EdgeNumberElement['value']> = {
+    getInputHandler(ref: StateRef<schema.EdgeNumberElement['value']>, grid: Grid, svg: SVGSVGElement): InputHandler {
         return getInputHandler(ref, grid, svg, { svgCoord2idx: svgCoord2edgeIdx, max: 10 });
     },
     order: 141,
@@ -89,12 +89,12 @@ export const ratioInfo: ElementInfo = {
     },
 };
 
-export const xvInfo: ElementInfo = {
-    getInputHandler(ref: StateRef, grid: Grid, svg: SVGSVGElement): InputHandler {
+export const xvInfo: ElementInfo<schema.EdgeNumberElement['value']> = {
+    getInputHandler(ref: StateRef<schema.EdgeNumberElement['value']>, grid: Grid, svg: SVGSVGElement): InputHandler {
         return getInputHandler(ref, grid, svg, {
             svgCoord2idx: svgCoord2edgeIdx,
             keymap: {
-                // TODO this is jank.
+                // TODO(mingwei) this is jank in that it is only used for XV.
                 KeyX: 10,
                 KeyV: 5,
             },
@@ -132,8 +132,8 @@ export const xvInfo: ElementInfo = {
     },
 };
 
-export const littleKillerInfo: ElementInfo = {
-    getInputHandler(ref: StateRef, grid: Grid, svg: SVGSVGElement): InputHandler {
+export const littleKillerInfo: ElementInfo<schema.LittleKillerElement['value']> = {
+    getInputHandler(ref: StateRef<schema.LittleKillerElement['value']>, grid: Grid, svg: SVGSVGElement): InputHandler {
         return getInputHandler(ref, grid, svg, { svgCoord2idx: svgCoord2diagonalIdx, max: 100 });
     },
     order: 160,
@@ -162,8 +162,8 @@ export const littleKillerInfo: ElementInfo = {
     },
 };
 
-export const sandwichInfo: ElementInfo = {
-    getInputHandler(ref: StateRef, grid: Grid, svg: SVGSVGElement): InputHandler {
+export const sandwichInfo: ElementInfo<schema.SeriesNumberElement['value']> = {
+    getInputHandler(ref: StateRef<schema.SeriesNumberElement['value']>, grid: Grid, svg: SVGSVGElement): InputHandler {
         return getInputHandler(ref, grid, svg, { svgCoord2idx: svgCoord2seriesIdx, max: 100 });
     },
     order: 150,
@@ -203,8 +203,8 @@ export const sandwichInfo: ElementInfo = {
     },
 };
 
-export const skyscraperInfo: ElementInfo = {
-    getInputHandler(ref: StateRef, grid: Grid, svg: SVGSVGElement): InputHandler {
+export const skyscraperInfo: ElementInfo<schema.SeriesNumberElement['value']> = {
+    getInputHandler(ref: StateRef<schema.SeriesNumberElement['value']>, grid: Grid, svg: SVGSVGElement): InputHandler {
         return getInputHandler(ref, grid, svg, {
             svgCoord2idx: svgCoord2seriesIdx,
             max: Math.max(grid.width, grid.height),
@@ -255,8 +255,8 @@ export const skyscraperInfo: ElementInfo = {
     },
 };
 
-export const xsumInfo: ElementInfo = {
-    getInputHandler(ref: StateRef, grid: Grid, svg: SVGSVGElement): InputHandler {
+export const xsumInfo: ElementInfo<schema.SeriesNumberElement['value']> = {
+    getInputHandler(ref: StateRef<schema.SeriesNumberElement['value']>, grid: Grid, svg: SVGSVGElement): InputHandler {
         return getInputHandler(ref, grid, svg, { svgCoord2idx: svgCoord2seriesIdx, max: 100 });
     },
     order: 152,
@@ -296,7 +296,7 @@ type PositionNumberInputHandlerOptions<TAG extends Geometry> = {
 };
 
 function getInputHandler<TAG extends Geometry>(
-    ref: StateRef,
+    ref: StateRef<IdxMap<TAG, true | number> | undefined>,
     grid: Grid,
     svg: SVGSVGElement,
     options: PositionNumberInputHandlerOptions<TAG>,
@@ -304,7 +304,7 @@ function getInputHandler<TAG extends Geometry>(
     const keymap = options.keymap || {};
     const { max, svgCoord2idx } = options;
 
-    let idxRef: null | StateRef = null;
+    let idxRef: null | StateRef<true | number> = null;
 
     function onDigitInput(code: string): boolean {
         if (null == idxRef) return false;
@@ -317,7 +317,7 @@ function getInputHandler<TAG extends Geometry>(
         }
         if (undefined === digit) return false;
 
-        const oldVal = idxRef.get<true | number>();
+        const oldVal = idxRef.get();
         if (null != digit && 'number' === typeof oldVal) {
             const multiDigit = oldVal * 10 + digit;
             if (multiDigit < max) digit = multiDigit;
@@ -332,7 +332,7 @@ function getInputHandler<TAG extends Geometry>(
     function handleClick(mousePosition: { offsetX: number; offsetY: number }) {
         const idx = svgCoord2idx(click2svgCoord(mousePosition, svg), grid);
         if (null == idx) return;
-        const clickedIdxRef = ref.ref(`${idx}`);
+        const clickedIdxRef = ref.ref<number | true>(`${idx}`);
 
         if (true === clickedIdxRef.get()) {
             // Delete empty.

--- a/packages/web/src/lib/js/element/quadruple.ts
+++ b/packages/web/src/lib/js/element/quadruple.ts
@@ -15,7 +15,7 @@ import { userCursorIsShownState, userSelectState } from '../user';
 import type { ElementInfo } from './element';
 import { pushHistory } from '../history';
 
-export const quadrupleInfo: ElementInfo = {
+export const quadrupleInfo: ElementInfo<schema.QuadrupleElement['value']> = {
     getInputHandler,
     order: 110,
     inGlobalMenu: false,
@@ -55,9 +55,13 @@ export const quadrupleInfo: ElementInfo = {
     },
 };
 
-function getInputHandler(ref: StateRef, grid: Grid, svg: SVGSVGElement): InputHandler {
+function getInputHandler(
+    ref: StateRef<schema.QuadrupleElement['value']>,
+    grid: Grid,
+    svg: SVGSVGElement,
+): InputHandler {
     const digits: number[] = [];
-    let cornerRef: null | StateRef = null;
+    let cornerRef: null | StateRef<true | ArrayObj<number>> = null;
     let maxLen = 4;
 
     function onDigitInput(code: string): boolean {
@@ -67,7 +71,7 @@ function getInputHandler(ref: StateRef, grid: Grid, svg: SVGSVGElement): InputHa
         if (undefined === digit) return false;
 
         if (null == digit) {
-            if (true === cornerRef.get<true | ArrayObj<number>>()) {
+            if (true === cornerRef.get()) {
                 // Already empty -> delete.
                 const diff = cornerRef.replace(null);
                 pushHistory(diff);
@@ -93,7 +97,7 @@ function getInputHandler(ref: StateRef, grid: Grid, svg: SVGSVGElement): InputHa
         if (null == coord) return;
 
         const idx = cornerCoord2cornerIdx(coord, grid);
-        const clickedCornerRef = ref.ref(`${idx}`);
+        const clickedCornerRef = ref.ref<true | ArrayObj<number>>(`${idx}`);
 
         maxLen = 4;
         if (coord[0] <= 0 || grid.width <= coord[0]) maxLen *= 0.5;

--- a/packages/web/src/lib/js/element/region.ts
+++ b/packages/web/src/lib/js/element/region.ts
@@ -15,8 +15,8 @@ import { pushHistory } from '../history';
 import { userCursorIsShownState, userSelectState } from '../user';
 import type { ElementInfo } from './element';
 
-export const minInfo: ElementInfo = {
-    getInputHandler(ref: StateRef, grid: Grid, svg: SVGSVGElement): InputHandler {
+export const minInfo: ElementInfo<schema.RegionElement['value']> = {
+    getInputHandler(ref: StateRef<schema.RegionElement['value']>, grid: Grid, svg: SVGSVGElement): InputHandler {
         return getInputHandler(ref, grid, svg, 'max');
     },
     order: 20,
@@ -47,8 +47,8 @@ export const minInfo: ElementInfo = {
     },
 };
 
-export const maxInfo: ElementInfo = {
-    getInputHandler(ref: StateRef, grid: Grid, svg: SVGSVGElement): InputHandler {
+export const maxInfo: ElementInfo<schema.RegionElement['value']> = {
+    getInputHandler(ref: StateRef<schema.RegionElement['value']>, grid: Grid, svg: SVGSVGElement): InputHandler {
         return getInputHandler(ref, grid, svg, 'min');
     },
     order: 21,
@@ -80,8 +80,8 @@ export const maxInfo: ElementInfo = {
     },
 };
 
-export const evenInfo: ElementInfo = {
-    getInputHandler(ref: StateRef, grid: Grid, svg: SVGSVGElement): InputHandler {
+export const evenInfo: ElementInfo<schema.RegionElement['value']> = {
+    getInputHandler(ref: StateRef<schema.RegionElement['value']>, grid: Grid, svg: SVGSVGElement): InputHandler {
         return getInputHandler(ref, grid, svg, 'odd');
     },
     order: 40,
@@ -104,8 +104,8 @@ export const evenInfo: ElementInfo = {
     },
 };
 
-export const oddInfo: ElementInfo = {
-    getInputHandler(ref: StateRef, grid: Grid, svg: SVGSVGElement): InputHandler {
+export const oddInfo: ElementInfo<schema.RegionElement['value']> = {
+    getInputHandler(ref: StateRef<schema.RegionElement['value']>, grid: Grid, svg: SVGSVGElement): InputHandler {
         return getInputHandler(ref, grid, svg, 'even');
     },
     order: 41,
@@ -128,9 +128,9 @@ export const oddInfo: ElementInfo = {
     },
 };
 
-export const columnIndexerInfo: ElementInfo = {
-    getInputHandler(ref: StateRef, grid: Grid, svg: SVGSVGElement): InputHandler {
-        return getInputHandler(ref, grid, svg, '');
+export const columnIndexerInfo: ElementInfo<schema.RegionElement['value']> = {
+    getInputHandler(ref: StateRef<schema.RegionElement['value']>, grid: Grid, svg: SVGSVGElement): InputHandler {
+        return getInputHandler(ref, grid, svg);
     },
     order: 42,
     inGlobalMenu: false,
@@ -159,9 +159,9 @@ export const columnIndexerInfo: ElementInfo = {
     },
 };
 
-export const rowIndexerInfo: ElementInfo = {
-    getInputHandler(ref: StateRef, grid: Grid, svg: SVGSVGElement): InputHandler {
-        return getInputHandler(ref, grid, svg, '');
+export const rowIndexerInfo: ElementInfo<schema.RegionElement['value']> = {
+    getInputHandler(ref: StateRef<schema.RegionElement['value']>, grid: Grid, svg: SVGSVGElement): InputHandler {
+        return getInputHandler(ref, grid, svg);
     },
     order: 42,
     inGlobalMenu: false,
@@ -190,7 +190,16 @@ export const rowIndexerInfo: ElementInfo = {
     },
 };
 
-function getInputHandler(stateRef: StateRef, grid: Grid, svg: SVGSVGElement, oppositeConstraint: string): InputHandler {
+/**
+ * @param oppositeConstraint - Another constraint that this constraint cannot share cells with. So attempting to place
+ *      this constraint there will ignore that cell.
+ */
+function getInputHandler(
+    stateRef: StateRef<schema.RegionElement['value']>,
+    grid: Grid,
+    svg: SVGSVGElement,
+    oppositeConstraint?: string,
+): InputHandler {
     const pointerHandler = new AdjacentCellPointerHandler(true);
 
     enum Mode {
@@ -209,13 +218,15 @@ function getInputHandler(stateRef: StateRef, grid: Grid, svg: SVGSVGElement, opp
         if (Mode.DYNAMIC === mode) {
             // If the first cell already has the constraint, set mode to removing
             // Otherwise, set mode to adding
-            mode = stateRef.ref(`${idx}`).get<true>() ? Mode.REMOVING : Mode.ADDING;
+            mode = stateRef.ref<true>(`${idx}`).get() ? Mode.REMOVING : Mode.ADDING;
         }
 
-        const oppositeConstraintValue = getCellValue(oppositeConstraint, idx);
-        if (oppositeConstraintValue) {
-            // Cannot place constraint if the opposite constraint is already in the cell
-            return;
+        if (null != oppositeConstraint) {
+            const oppositeConstraintValue = getCellValue(oppositeConstraint, idx);
+            if (oppositeConstraintValue) {
+                // Cannot place constraint if the opposite constraint is already in the cell
+                return;
+            }
         }
 
         const stateValue = mode === Mode.ADDING ? true : null;

--- a/packages/web/src/lib/js/element/toggles.ts
+++ b/packages/web/src/lib/js/element/toggles.ts
@@ -10,7 +10,7 @@ import {
 } from '@sudoku-studio/board-utils/src';
 import type { ElementInfo } from './element';
 
-export const diagonalInfo: ElementInfo = {
+export const diagonalInfo: ElementInfo<schema.DiagonalElement['value']> = {
     inGlobalMenu: true,
     order: 0,
     menu: {
@@ -43,7 +43,7 @@ export const diagonalInfo: ElementInfo = {
     meta: { description: 'Digits along the marked diagonal(s) may not repeat.', tags: ['x'], category: ['global'] },
 };
 
-export const disjointGroupsInfo: ElementInfo = {
+export const disjointGroupsInfo: ElementInfo<schema.BooleanElement['value']> = {
     inGlobalMenu: true,
     order: 0,
     menu: {
@@ -81,7 +81,7 @@ export const disjointGroupsInfo: ElementInfo = {
     },
 };
 
-export const consecutiveInfo: ElementInfo = {
+export const consecutiveInfo: ElementInfo<schema.ConsecutiveElement['value']> = {
     inGlobalMenu: true,
     order: 0,
     menu: {
@@ -112,7 +112,7 @@ export const consecutiveInfo: ElementInfo = {
     meta: { description: '[Edge- | Corner-] adjacent digits may not be consecutive.', tags: [], category: ['global'] },
 };
 
-export const antiXInfo: ElementInfo = {
+export const antiXInfo: ElementInfo<schema.BooleanElement['value']> = {
     inGlobalMenu: true,
     order: 0,
     menu: { type: 'checkbox', name: 'Anti-X', checkbox: { name: 'Anti-X', icon: 'anti-x' }, icon: 'anti-x' },
@@ -130,7 +130,7 @@ export const antiXInfo: ElementInfo = {
     meta: { description: 'Adjacent digits may not sum to 10.', tags: [], category: ['global'] },
 };
 
-export const antiVInfo: ElementInfo = {
+export const antiVInfo: ElementInfo<schema.BooleanElement['value']> = {
     inGlobalMenu: true,
     order: 0,
     menu: { type: 'checkbox', name: 'Anti-V', checkbox: { name: 'Anti-V', icon: 'anti-v' }, icon: 'anti-v' },
@@ -148,7 +148,7 @@ export const antiVInfo: ElementInfo = {
     meta: { description: 'Adjacent digits may not sum to 5.', tags: [], category: ['global'] },
 };
 
-export const kingInfo: ElementInfo = {
+export const kingInfo: ElementInfo<schema.BooleanElement['value']> = {
     inGlobalMenu: true,
     order: 0,
     menu: { type: 'checkbox', name: 'Antiking', checkbox: { name: 'Antiking', icon: 'king' }, icon: 'king' },
@@ -174,7 +174,7 @@ export const kingInfo: ElementInfo = {
     },
 };
 
-export const knightInfo: ElementInfo = {
+export const knightInfo: ElementInfo<schema.BooleanElement['value']> = {
     inGlobalMenu: true,
     order: 0,
     menu: { type: 'checkbox', name: 'Antiknight', checkbox: { name: 'Antiknight', icon: 'knight' }, icon: 'knight' },
@@ -200,7 +200,7 @@ export const knightInfo: ElementInfo = {
     },
 };
 
-export const selfTaxicabInfo: ElementInfo = {
+export const selfTaxicabInfo: ElementInfo<schema.BooleanElement['value']> = {
     inGlobalMenu: true,
     order: 0,
     menu: {
@@ -209,6 +209,7 @@ export const selfTaxicabInfo: ElementInfo = {
         checkbox: { name: 'Self-Taxicab', icon: 'cityblock' },
         icon: 'cityblock',
     },
+    // TODO: getWarnings
 };
 
 function getConsecutiveWarnings(

--- a/packages/web/src/lib/js/elementStores.ts
+++ b/packages/web/src/lib/js/elementStores.ts
@@ -9,7 +9,12 @@ import type { InputHandler } from './input/inputHandler';
 import { pushHistory } from './history';
 import { boardRepr, buildRegionMap, getDigits } from '@sudoku-studio/board-utils/src';
 
-export type ElementHandlerItem = { id: string; elementRef: StateRef; info: ElementInfo; type: schema.ElementType };
+export type ElementHandlerItem = {
+    id: string;
+    elementRef: StateRef;
+    info: ElementInfo<unknown>;
+    type: schema.ElementType;
+};
 export type ElementHandlerList = ElementHandlerItem[];
 
 export function addElement<E extends schema.Element>(type: E['type'], value?: E['value']): string {
@@ -59,7 +64,7 @@ export function removeElement(id: string): void {
 export const elementHandlers = readable<ElementHandlerList>([], (set) => {
     const list: ElementHandlerList = [];
 
-    boardState.ref('elements/*').watch<schema.Element>(([_elements, elementId], oldVal, newVal) => {
+    boardState.ref<schema.Element>('elements/*').watch(([_elements, elementId], oldVal, newVal) => {
         const type = oldVal?.type || newVal?.type;
 
         // Element has been deleted via undo/redo
@@ -105,12 +110,12 @@ export const elementHandlers = readable<ElementHandlerList>([], (set) => {
     }, true);
 });
 
-boardState.ref('elements').watch<schema.Board['elements']>((_path, _oldElements, newElements) => {
+boardState.ref<schema.Board['elements']>('elements').watch((_path, _oldElements, newElements) => {
     if (null == newElements) return;
     const digits = getDigits(newElements);
 
     const warnings: IdxBitset<Geometry.CELL> = {};
-    const grid = boardGridRef.get<Grid>();
+    const grid = boardGridRef.get();
     const gridRegionMap = buildRegionMap(newElements);
     for (const { type, value } of Object.values(newElements)) {
         const handler = ELEMENT_HANDLERS[type];
@@ -139,7 +144,7 @@ export const currentInputHandler = derived<
 >([currentElement, boardSvg, boardGridRef], ([$currentElement, $boardSvg, $boardGridRef]) => {
     if (null == $currentElement) return null;
     const { info, elementRef } = $currentElement;
-    const valueRef = elementRef.ref('value');
+    const valueRef = elementRef.ref<any>('value');
     if (null == info || null == info.getInputHandler) return null;
 
     const inputHandler = info.getInputHandler(valueRef, $boardGridRef, $boardSvg);

--- a/packages/web/src/lib/js/elements.ts
+++ b/packages/web/src/lib/js/elements.ts
@@ -92,7 +92,7 @@ export const ELEMENT_HANDLERS = {
     ['antiX']: antiXInfo,
     ['antiV']: antiVInfo,
     ['selfTaxicab']: selfTaxicabInfo,
-} as Record<schema.ElementType, ElementInfo>;
+} as Record<schema.ElementType, ElementInfo<unknown>>;
 
 export function createElement<E extends schema.Element>(type: E['type'], value?: E['value']): E {
     if (!(type in ELEMENT_HANDLERS)) throw Error(`Cannot add unknown element type: ${type}.`);
@@ -102,13 +102,13 @@ export function createElement<E extends schema.Element>(type: E['type'], value?:
     return { type, order: handler.order, value: value } as E;
 }
 
-function getSearchableElements(filterFunction: (key: string, info: ElementInfo) => boolean) {
+function getSearchableElements(filterFunction: (key: string, info: ElementInfo<unknown>) => boolean) {
     return Object.entries(ELEMENT_HANDLERS)
         .filter(([key, info]) => null != info.menu && filterFunction(key, info))
         .map(([key, info]) => ({ key, info }));
 }
 
-function buildElementsFuse(searchableElements: { key: string; info: ElementInfo }[]) {
+function buildElementsFuse(searchableElements: { key: string; info: ElementInfo<unknown> }[]) {
     return new Fuse(searchableElements, {
         keys: [
             { name: 'info.menu.name', weight: 1 },
@@ -119,7 +119,7 @@ function buildElementsFuse(searchableElements: { key: string; info: ElementInfo 
     });
 }
 
-export function search(fuzzyPattern: string, filterFunction: (key: string, info: ElementInfo) => boolean) {
+export function search(fuzzyPattern: string, filterFunction: (key: string, info: ElementInfo<unknown>) => boolean) {
     const searchableElements = getSearchableElements(filterFunction);
 
     if (!fuzzyPattern) {

--- a/packages/web/src/lib/js/input/lineInputHandler.ts
+++ b/packages/web/src/lib/js/input/lineInputHandler.ts
@@ -1,5 +1,5 @@
 import { arrayObj2array, boardRepr, cellCoord2CellIdx } from '@sudoku-studio/board-utils/src';
-import type { ArrayObj, Geometry, Grid, Idx } from '@sudoku-studio/schema';
+import type { ArrayObj, Geometry, Grid, Idx, schema } from '@sudoku-studio/schema';
 import type { Diff, StateRef } from '@sudoku-studio/state-manager/src';
 import { pushHistory } from '../history';
 import { userCursorIsShownState, userSelectState } from '../user';
@@ -14,7 +14,7 @@ export type LineInputHandlerOptions = {
 };
 
 export function getLineInputHandler(
-    stateRef: StateRef,
+    stateRef: StateRef<schema.LineElement['value']>,
     grid: Grid,
     svg: SVGSVGElement,
     options: LineInputHandlerOptions,
@@ -76,9 +76,7 @@ export function getLineInputHandler(
         const idx = cellCoord2CellIdx(coord, grid);
 
         let lineIdToDelete: null | string = null;
-        for (const [lineId, lineValArrObj] of Object.entries(
-            stateRef.get<Record<string, ArrayObj<Idx<Geometry.CELL>>>>() || {},
-        )) {
+        for (const [lineId, lineValArrObj] of Object.entries(stateRef.get() || {})) {
             const lineValCells = arrayObj2array(lineValArrObj);
             if (deletePrioritizeHead && idx === lineValCells[0]) {
                 lineIdToDelete = lineId;

--- a/packages/web/src/lib/js/input/selectDigitInputHandler.ts
+++ b/packages/web/src/lib/js/input/selectDigitInputHandler.ts
@@ -1,5 +1,5 @@
 import { idxMapToKeysArray, cellCoord2CellIdx, cellIdx2cellCoord } from '@sudoku-studio/board-utils/src';
-import type { Geometry, Grid, Idx, IdxBitset } from '@sudoku-studio/schema';
+import type { Geometry, Grid, Idx, IdxBitset, IdxMap, schema, user } from '@sudoku-studio/schema';
 import type { StateRef, Update } from '@sudoku-studio/state-manager/src';
 import { boardState, getCellValue, getDigits } from '../board';
 import { pushHistory } from '../history';
@@ -28,8 +28,18 @@ export type DigitInputHandlerOptions = {
     digitMapping?: null | (string | number)[];
 };
 
+type StateRefSelectDigitInputHandler =
+    | StateRef<schema.DigitElement['value']>
+    | StateRef<schema.PencilMarksElement['value']>
+    | StateRef<schema.ColorsElement['value']>
+    | StateRef<SelectDigitInputHandlerValue>;
+type SelectDigitInputHandlerValue =
+    | schema.DigitElement['value']
+    | schema.PencilMarksElement['value']
+    | schema.ColorsElement['value'];
+
 export function getSelectDigitInputHandler(
-    stateRef: StateRef,
+    stateRef: StateRefSelectDigitInputHandler,
     grid: Grid,
     svg: SVGSVGElement,
     options: DigitInputHandlerOptions,
@@ -41,31 +51,34 @@ export function getSelectDigitInputHandler(
     function onDigitInput(code: string): boolean {
         let digit: undefined | null | number | string = parseDigit(code);
 
-        if (digitMapping && null != digit && digit in digitMapping) digit = digitMapping[digit];
-
-        if (undefined === digit) return false;
+        if (digitMapping && null != digit && digit in digitMapping) {
+            digit = digitMapping[digit];
+        }
+        if (undefined === digit) {
+            return false;
+        }
 
         const shouldDelegate = onDigitInputHelper(stateRef, digit);
         if (shouldDelegate) {
             for (const type of DELETE_ORDER) {
-                const elementId = userState.get('marks', type);
+                const elementId = userState.get<string>('marks', type);
                 if (null == elementId) continue;
 
-                const otherRef = boardState.ref('elements', `${elementId}`, 'value');
+                const otherRef = boardState.ref<SelectDigitInputHandlerValue>('elements', `${elementId}`, 'value');
                 if (!onDigitInputHelper(otherRef, digit)) break;
             }
         }
         return true;
     }
 
-    function onDigitInputHelper(stateRef: StateRef, digit: null | number | string): boolean {
+    function onDigitInputHelper(stateRef: StateRefSelectDigitInputHandler, digit: null | number | string): boolean {
         const blockingDigits = getDigits(null != digit && blockedByGivens, null != digit && blockedByFilled);
 
         const update: Update = {};
         // Keep track of if all marks are already set, and if so delete them instead of adding them.
         let allAlreadySet = true;
 
-        for (const cellIdx of idxMapToKeysArray(userSelectState.get<IdxBitset<Geometry.CELL>>())) {
+        for (const cellIdx of idxMapToKeysArray(userSelectState.get())) {
             // Ignore filled/given digits as needed.
             if (null != blockingDigits[cellIdx]) continue;
 
@@ -114,7 +127,10 @@ export function getSelectDigitInputHandler(
 
     function onQuickshift(event: KeyboardEvent): boolean {
         if ('keydown' === event.type && event.code in MODE_SHORTCUTS) {
-            const newToolState = userState.get('marks', MODE_SHORTCUTS[event.code as keyof typeof MODE_SHORTCUTS]);
+            const newToolState = userState.get<string>(
+                'marks',
+                MODE_SHORTCUTS[event.code as keyof typeof MODE_SHORTCUTS],
+            );
             userToolState.replace(newToolState);
             userPrevToolState.replace(newToolState);
             return true;
@@ -426,7 +442,7 @@ export function getSelectDigitInputHandler(
         if (Mode.RESETTING === mode) {
             const { coord, grid } = event;
             const cellIndex = cellCoord2CellIdx(coord, grid);
-            const selection = userSelectState.get<Record<string, true>>() || {};
+            const selection = userSelectState.get() || {};
 
             // Special: Tapping on a single cell acts as a toggle
             if (1 === Object.keys(selection).length && selection[cellIndex]) {

--- a/packages/web/src/lib/js/user.ts
+++ b/packages/web/src/lib/js/user.ts
@@ -1,10 +1,10 @@
 import { browser } from '$app/environment';
-import { StateManager, StateRef } from '@sudoku-studio/state-manager/src';
-import type { schema } from '@sudoku-studio/schema';
+import { StateManager } from '@sudoku-studio/state-manager/src';
+import type { Geometry, Idx, IdxBitset, schema, user } from '@sudoku-studio/schema';
 
 export const MARK_TYPES = ['filled', 'corner', 'center', 'colors'] as const;
 
-export const userState = new StateManager();
+export const userState = new StateManager<user.UserState>();
 if (browser) {
     (window as any).userState = userState;
 }
@@ -25,7 +25,7 @@ userState.update({
     historyUndone: {},
 });
 
-export function getUserToolStateName(toolState: StateRef | null): string | null {
+export function getUserToolStateName(toolState: string | null): string | null {
     switch (toolState) {
         case userState.get('marks', 'filled'):
             return 'filled';
@@ -40,12 +40,12 @@ export function getUserToolStateName(toolState: StateRef | null): string | null 
     }
 }
 
-export const userSelectState = userState.ref('select');
-export const userCursorIndexState = userState.ref('cursor', 'index');
-export const userCursorIsShownState = userState.ref('cursor', 'isShown');
+export const userSelectState = userState.ref<IdxBitset<Geometry.CELL>>('select');
+export const userCursorIndexState = userState.ref<Idx<Geometry.CELL> | null>('cursor', 'index');
+export const userCursorIsShownState = userState.ref<boolean>('cursor', 'isShown');
 
-export const userPrevToolState = userState.ref('prevTool');
-export const userToolState = userState.ref('tool');
+export const userPrevToolState = userState.ref<string>('prevTool');
+export const userToolState = userState.ref<string>('tool');
 export const TOOL_INPUT_NAME = 'tool';
 
 /** Load tools and pencil marks for the user. */

--- a/packages/web/src/lib/svelte/edit/AddModal.svelte
+++ b/packages/web/src/lib/svelte/edit/AddModal.svelte
@@ -6,7 +6,7 @@
     import Modal from '../Modal.svelte';
 
     export let visible = false;
-    export let filterFunction: (key: string, info: ElementInfo) => boolean;
+    export let filterFunction: (key: string, info: ElementInfo<unknown>) => boolean;
     export let searchPattern: string = '';
 
     let searchInput: HTMLInputElement = null!;

--- a/packages/web/src/lib/svelte/edit/EditPanel.svelte
+++ b/packages/web/src/lib/svelte/edit/EditPanel.svelte
@@ -2,7 +2,6 @@
     import type { Component, ComponentInternals } from 'svelte';
     import type { ElementHandlerList } from '$lib/js/elementStores';
     import type { ElementInfo } from '$lib/js/element/element';
-    import type { schema } from '@sudoku-studio/schema';
 
     import EditSection from './EditSection.svelte';
     import { elementHandlers } from '$lib/js/elementStores';
@@ -16,11 +15,11 @@
         return !$elementHandlers.some(({ type }) => key === type);
     }
 
-    function isGlobalConstraint(info: ElementInfo): boolean {
+    function isGlobalConstraint(info: ElementInfo<unknown>): boolean {
         return null != info.menu && !!info.inGlobalMenu;
     }
 
-    function isLocalConstraint(info: ElementInfo): boolean {
+    function isLocalConstraint(info: ElementInfo<unknown>): boolean {
         return null != info.menu && !info.inGlobalMenu;
     }
 
@@ -37,10 +36,12 @@
         },
     );
 
-    const globalConstraintFilter = (key: string, info: ElementInfo) => isNewConstraint(key) && isGlobalConstraint(info);
-    const localConstraintFilter = (key: string, info: ElementInfo) => isNewConstraint(key) && isLocalConstraint(info);
+    const globalConstraintFilter = (key: string, info: ElementInfo<unknown>) =>
+        isNewConstraint(key) && isGlobalConstraint(info);
+    const localConstraintFilter = (key: string, info: ElementInfo<unknown>) =>
+        isNewConstraint(key) && isLocalConstraint(info);
 
-    function componentFor(element: ElementInfo): Component | null {
+    function componentFor(element: ElementInfo<unknown>): Component | null {
         const menuInfo = element.menu;
         if (null == menuInfo) return null;
         return (internals: ComponentInternals, props: any) => {
@@ -58,7 +59,7 @@
 
     let modalSearchPattern = '';
     let showAddModal: boolean = false;
-    let constraintFilterFunction = (_key: string, _info: ElementInfo) => true;
+    let constraintFilterFunction = (_key: string, _info: ElementInfo<unknown>) => true;
 </script>
 
 <ul class="nolist">

--- a/packages/web/src/lib/svelte/edit/constraint/Checkbox.svelte
+++ b/packages/web/src/lib/svelte/edit/constraint/Checkbox.svelte
@@ -8,10 +8,10 @@
 
     export let name: string;
     export let icon: string;
-    export let checked: StateRef;
+    export let checked: StateRef<boolean>;
 
     function onClick() {
-        const diff = checked.replace(!checked.get<boolean>());
+        const diff = checked.replace(!checked.get());
         pushHistory(diff);
     }
 </script>

--- a/packages/web/src/lib/svelte/edit/constraint/CheckboxMenuComponent.svelte
+++ b/packages/web/src/lib/svelte/edit/constraint/CheckboxMenuComponent.svelte
@@ -11,14 +11,14 @@
     export let info: CheckboxMenuComponent;
     export let deletable: boolean;
 
-    const valueRef = elementRef.ref('value');
+    const valueRef = elementRef.ref<boolean | Record<string, boolean>>('value');
 
     function onClick() {
         if (!Array.isArray(info.checkbox)) {
-            const diff = valueRef.replace(!valueRef.get<boolean>());
+            const diff = valueRef.replace(!valueRef.get());
             pushHistory(diff);
         } else {
-            const val = info.checkbox.some(({ refPath }) => !valueRef.ref(refPath).get<boolean>());
+            const val = info.checkbox.some(({ refPath }) => !valueRef.ref<boolean>(refPath).get());
             const dict: Record<string, boolean> = {};
             for (const { refPath } of info.checkbox) {
                 dict[refPath] = val;
@@ -33,13 +33,13 @@
         if (!Array.isArray(info.checkbox)) {
             return !data;
         } else {
-            return info.checkbox.every(({ refPath }) => !valueRef.ref(refPath).get<boolean>());
+            return info.checkbox.every(({ refPath }) => !valueRef.ref<boolean>(refPath).get());
         }
     }
 </script>
 
 <ConstraintRow {id} {deletable} name={info.name} unused={unused($valueRef)} {onClick} onTrash={() => removeElement(id)}>
     {#each Array.isArray(info.checkbox) ? info.checkbox : [info.checkbox] as { name, icon, refPath }}
-        <Checkbox {name} {icon} checked={refPath ? valueRef.ref(refPath) : valueRef} />
+        <Checkbox {name} {icon} checked={refPath ? valueRef.ref<boolean>(refPath) : (valueRef as StateRef<boolean>)} />
     {/each}
 </ConstraintRow>

--- a/packages/web/src/lib/svelte/entry/EntryPanel.svelte
+++ b/packages/web/src/lib/svelte/entry/EntryPanel.svelte
@@ -18,9 +18,13 @@
     onDestroy(() => window.removeEventListener('resize', onResize));
     requestAnimationFrame(onResize); // Run on load.
 
+    const title = boardState.ref<string>('meta', 'title');
+    const author = boardState.ref<string>('meta', 'author');
+    const description = boardState.ref<string>('meta', 'description');
+
     function updateWindowTitle() {
-        const puzzleTitle = title.get<string>();
-        const puzzleAuthor = author.get<string>();
+        const puzzleTitle = title.get();
+        const puzzleAuthor = author.get();
         let windowTitle: string;
 
         if (puzzleTitle && puzzleAuthor) {
@@ -33,10 +37,6 @@
 
         document.title = windowTitle;
     }
-
-    const title = boardState.ref('meta', 'title');
-    const author = boardState.ref('meta', 'author');
-    const description = boardState.ref('meta', 'description');
 
     updateWindowTitle();
 </script>


### PR DESCRIPTION
Makes development a lot easier by showing what value each element has.

Fixes a type bug that had boolean elements having value `{ positive: boolean, negative: boolean }` (like diagonals) instead of just `boolean`.