### PR TITLE
refactor: board elements upgraded to svelte 5, add types to `StateRef` usages

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,11 @@
 {
-    "editor.defaultFormatter": "esbenp.prettier-vscode",
     "editor.formatOnSave": true,
+    "[css]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },
+    "[scss]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },
     "[javascript]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },
     "[json]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },
     "[jsonc]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },
+    "[svelte]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },
     "[typescript]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },
     "[yaml]": { "editor.defaultFormatter": "esbenp.prettier-vscode" }
 }

--- a/packages/board/src/lib/Board.svelte
+++ b/packages/board/src/lib/Board.svelte
@@ -1,6 +1,6 @@
 <script lang="ts" context="module">
     import type { Component, ComponentInternals, ComponentProps } from 'svelte';
-    import type { Geometry, Grid, Idx, schema, user } from '@sudoku-studio/schema';
+    import type { Geometry, Grid, Idx, IdxBitset, schema, user } from '@sudoku-studio/schema';
     import type { StateManager, StateRef } from '@sudoku-studio/state-manager/src';
 
     import { derived, readable } from 'svelte/store';
@@ -46,23 +46,23 @@
     import NullRender from './svelte/NullRender.svelte';
     import CloneRender from './svelte/CloneRender.svelte';
 
-    const WarningRender: Component<ComponentProps<SelectRender>> = (
+    const WarningRender: Component<ComponentProps<typeof SelectRender>> = (
         internals: ComponentInternals,
-        props: ComponentProps<SelectRender>,
+        props: ComponentProps<typeof SelectRender>,
     ) => {
         return SelectRender(internals, { ...props, fill: '#f33', outlineOpacity: '#eee', innerOpacity: '#333' });
     };
 
-    const FilledRender: Component<ComponentProps<DigitRender>> = (
+    const FilledRender: Component<ComponentProps<typeof DigitRender>> = (
         internals: ComponentInternals,
-        props: ComponentProps<DigitRender>,
+        props: ComponentProps<typeof DigitRender>,
     ) => {
         return DigitRender(internals, { ...props, color: '#4e72b0', mask: 'url(#SUDOKU_MASK_GIVENS)' });
     };
 
-    const DifferenceRender: Component<ComponentProps<PositionNumberRender>> = (
+    const DifferenceRender: Component<ComponentProps<typeof PositionNumberRender>> = (
         internals: ComponentInternals,
-        props: ComponentProps<PositionNumberRender>,
+        props: ComponentProps<typeof PositionNumberRender>,
     ) => {
         return PositionNumberRender(internals, {
             ...props,
@@ -74,9 +74,9 @@
         });
     };
 
-    const RatioRender: Component<ComponentProps<PositionNumberRender>> = (
+    const RatioRender: Component<ComponentProps<typeof PositionNumberRender>> = (
         internals: ComponentInternals,
-        props: ComponentProps<PositionNumberRender>,
+        props: ComponentProps<typeof PositionNumberRender>,
     ) => {
         return PositionNumberRender(internals, {
             ...props,
@@ -87,9 +87,9 @@
         });
     };
 
-    const XVRender: Component<ComponentProps<PositionNumberRender>> = (
+    const XVRender: Component<ComponentProps<typeof PositionNumberRender>> = (
         internals: ComponentInternals,
-        props: ComponentProps<PositionNumberRender>,
+        props: ComponentProps<typeof PositionNumberRender>,
     ) => {
         return PositionNumberRender(internals, {
             ...props,
@@ -104,9 +104,9 @@
         });
     };
 
-    const SeriesRender: Component<ComponentProps<PositionNumberRender>> = (
+    const SeriesRender: Component<ComponentProps<typeof PositionNumberRender>> = (
         internals: ComponentInternals,
-        props: ComponentProps<PositionNumberRender>,
+        props: ComponentProps<typeof PositionNumberRender>,
     ) => {
         return PositionNumberRender(internals, {
             ...props,
@@ -121,16 +121,16 @@
         });
     };
 
-    const PalindromeRender: Component<ComponentProps<LineRender>> = (
+    const PalindromeRender: Component<ComponentProps<typeof LineRender>> = (
         internals: ComponentInternals,
-        props: ComponentProps<LineRender>,
+        props: ComponentProps<typeof LineRender>,
     ) => {
         return LineRender(internals, { ...props, stroke: '#ed8', strokeWidth: 0.125 });
     };
 
-    const GermanWhisperRender: Component<ComponentProps<LineRender>> = (
+    const GermanWhisperRender: Component<ComponentProps<typeof LineRender>> = (
         internals: ComponentInternals,
-        props: ComponentProps<LineRender>,
+        props: ComponentProps<typeof LineRender>,
     ) => {
         return LineRender(internals, {
             ...props,
@@ -140,9 +140,9 @@
         });
     };
 
-    const DutchWhisperRender: Component<ComponentProps<LineRender>> = (
+    const DutchWhisperRender: Component<ComponentProps<typeof LineRender>> = (
         internals: ComponentInternals,
-        props: ComponentProps<LineRender>,
+        props: ComponentProps<typeof LineRender>,
     ) => {
         return LineRender(internals, {
             ...props,
@@ -152,9 +152,9 @@
         });
     };
 
-    const RenbanRender: Component<ComponentProps<LineRender>> = (
+    const RenbanRender: Component<ComponentProps<typeof LineRender>> = (
         internals: ComponentInternals,
-        props: ComponentProps<LineRender>,
+        props: ComponentProps<typeof LineRender>,
     ) => {
         return LineRender(internals, {
             ...props,
@@ -164,9 +164,9 @@
         });
     };
 
-    const RegionSumRender: Component<ComponentProps<LineRender>> = (
+    const RegionSumRender: Component<ComponentProps<typeof LineRender>> = (
         internals: ComponentInternals,
-        props: ComponentProps<LineRender>,
+        props: ComponentProps<typeof LineRender>,
     ) => {
         return LineRender(internals, {
             ...props,
@@ -176,23 +176,23 @@
         });
     };
 
-    const SlowThermoRender: Component<ComponentProps<ThermoRender>> = (
+    const SlowThermoRender: Component<ComponentProps<typeof ThermoRender>> = (
         internals: ComponentInternals,
-        props: ComponentProps<ThermoRender>,
+        props: ComponentProps<typeof ThermoRender>,
     ) => {
         return ThermoRender(internals, { ...props, isSlow: true });
     };
 
-    const ColumnIndexerRender: Component<ComponentProps<IndexerRender>> = (
+    const ColumnIndexerRender: Component<ComponentProps<typeof IndexerRender>> = (
         internals: ComponentInternals,
-        props: ComponentProps<IndexerRender>,
+        props: ComponentProps<typeof IndexerRender>,
     ) => {
         return IndexerRender(internals, { ...props, color: '#C77C7C' });
     };
 
-    const RowIndexerRender: Component<ComponentProps<IndexerRender>> = (
+    const RowIndexerRender: Component<ComponentProps<typeof IndexerRender>> = (
         internals: ComponentInternals,
-        props: ComponentProps<IndexerRender>,
+        props: ComponentProps<typeof IndexerRender>,
     ) => {
         return IndexerRender(internals, { ...props, color: '#7CC77C' });
     };
@@ -269,29 +269,29 @@
 
 <script lang="ts">
     export let userState: undefined | null | StateManager<user.UserState>;
-    export let warningState: undefined | null | StateManager;
-    export let boardState: StateManager;
+    export let warningState: undefined | null | StateManager<IdxBitset<Geometry.CELL>>;
+    export let boardState: StateManager<schema.Board>;
     export let svg: SVGSVGElement = null!;
 
-    const grid = boardState.ref('grid');
+    const grid = boardState.ref<Grid>('grid');
 
-    const elementsRef = boardState.ref('elements');
+    const elementsRef = boardState.ref<schema.Board['elements']>('elements');
     const givensMaskPath = derived(
         [elementsRef, grid],
         ([elements, grid]) =>
-            getBorderPath(idxMapToKeysArray(getDigits(elements || {}, true, false)), grid, 0) || undefined,
+            getBorderPath(idxMapToKeysArray(getDigits(elements || {}, true, false)), grid!, 0) || undefined,
     );
     const givensFilledMaskPath = derived(
         [elementsRef, grid],
         ([elements, grid]) =>
-            getBorderPath(idxMapToKeysArray(getDigits(elements || {}, true, true)), grid, 0) || undefined,
+            getBorderPath(idxMapToKeysArray(getDigits(elements || {}, true, true)), grid!, 0) || undefined,
     );
 
     type ElementList<T extends keyof typeof ELEMENT_RENDERERS = any> = {
         id: string;
         type: T;
         order: number;
-        ref: StateRef;
+        ref: StateRef<ComponentProps<(typeof ELEMENT_RENDERERS)[T]>>;
         element: (typeof ELEMENT_RENDERERS)[T];
     }[];
 
@@ -356,7 +356,7 @@
                     id: elementId,
                     type,
                     order: newVal.order,
-                    ref: boardState.ref(_elements, elementId, 'value'),
+                    ref: boardState.ref<any>(_elements, elementId, 'value'),
                     element,
                 };
 
@@ -378,7 +378,12 @@
             .map(({ type }) => MARGINS[type as keyof typeof ELEMENT_RENDERERS] || 0)
             .filter<number>((margin): margin is number => null != margin)
             .reduce((a, b) => (a > b ? a : b), 0);
-        return { x: -margin, y: -margin, width: $grid?.width + 2 * margin, height: $grid?.height + 2 * margin };
+        return {
+            x: -margin,
+            y: -margin,
+            width: ($grid!.width || 0) + 2 * margin,
+            height: ($grid!.height || 0) + 2 * margin,
+        };
     });
 </script>
 

--- a/packages/board/src/lib/Board.svelte
+++ b/packages/board/src/lib/Board.svelte
@@ -378,12 +378,7 @@
             .map(({ type }) => MARGINS[type as keyof typeof ELEMENT_RENDERERS] || 0)
             .filter<number>((margin): margin is number => null != margin)
             .reduce((a, b) => (a > b ? a : b), 0);
-        return {
-            x: -margin,
-            y: -margin,
-            width: ($grid!.width || 0) + 2 * margin,
-            height: ($grid!.height || 0) + 2 * margin,
-        };
+        return { x: -margin, y: -margin, width: $grid!.width + 2 * margin, height: $grid!.height + 2 * margin };
     });
 </script>
 

--- a/packages/board/src/lib/svelte/ArrowRender.svelte
+++ b/packages/board/src/lib/svelte/ArrowRender.svelte
@@ -1,28 +1,15 @@
 <script lang="ts">
     import { makePath, arrayObj2array } from '@sudoku-studio/board-utils/src';
-    import type { schema } from '@sudoku-studio/schema';
+    import type { Grid, schema } from '@sudoku-studio/schema';
     import type { StateRef } from '@sudoku-studio/state-manager/src';
 
-    export let id: string;
-    export let ref: StateRef;
-    export let grid: { width: number; height: number };
+    const { id, ref, grid }: { id: string; ref: StateRef<schema.ArrowElement['value']>; grid: Grid } = $props();
 
     const bulbRadius = 0.375;
     const outlineWidth = 0.025;
     const strokeWidth = 0.025;
 
     const color = '#222';
-
-    type Item = { arrowId: string; dBulb: string; dBody: string };
-    function each(value: schema.ArrowElement['value']): Item[] {
-        const out: Item[] = [];
-        for (const [arrowId, { bulb, body }] of Object.entries(value || {})) {
-            const dBulb = makePath(arrayObj2array(bulb || {}), grid);
-            const dBody = makePath(arrayObj2array(body || {}), grid, { shortenHead: bulbRadius, shortenTail: 0.2 });
-            out.push({ arrowId, dBulb, dBody });
-        }
-        return out;
-    }
 </script>
 
 <marker
@@ -38,8 +25,10 @@
     <path d="M 0.4,0.425 L 0.5,0.5 L 0.4,0.575" fill="none" stroke={color} stroke-width={strokeWidth} />
 </marker>
 <g {id}>
-    {#each each($ref || {}) as { arrowId, dBulb, dBody } (arrowId)}
-        <mask id="arrow-{id}-mask-{arrowId}" maskUnits="userSpaceOnUse">
+    {#each Object.entries($ref || {}) as [itemId, { bulb, body }] (itemId)}
+        {@const dBulb = makePath(arrayObj2array(bulb || {}), grid)}
+        {@const dBody = makePath(arrayObj2array(body || {}), grid, { shortenHead: bulbRadius, shortenTail: 0.2 })}
+        <mask id="arrow-{id}-mask-{itemId}" maskUnits="userSpaceOnUse">
             <rect width={grid.width} height={grid.height} fill="#fff" />
             <path
                 d={dBulb}
@@ -55,7 +44,7 @@
             fill="none"
             stroke={color}
             stroke-width={2 * bulbRadius + outlineWidth}
-            mask="url(#arrow-{id}-mask-{arrowId})"
+            mask="url(#arrow-{id}-mask-{itemId})"
             stroke-linejoin="round"
             stroke-linecap="round"
         />

--- a/packages/board/src/lib/svelte/BetweenRender.svelte
+++ b/packages/board/src/lib/svelte/BetweenRender.svelte
@@ -1,40 +1,24 @@
 <script lang="ts">
-    import type { ArrayObj, Coord, Geometry, Idx } from '@sudoku-studio/schema';
+    import type { Grid, schema } from '@sudoku-studio/schema';
     import type { StateRef } from '@sudoku-studio/state-manager/src';
     import { makePath, arrayObj2array, cellIdx2cellCoord } from '@sudoku-studio/board-utils/src';
-    import { derived } from 'svelte/store';
 
-    export let id: string;
-    export let ref: StateRef;
-    export let grid: { width: number; height: number };
+    const { id, ref, grid }: { id: string; ref: StateRef<schema.LineElement['value']>; grid: Grid } = $props();
 
     const bulbRadius = 0.375;
     const outlineWidth = 0.025;
     const strokeWidth = 0.15;
-
-    type Item = { itemId: string; d: string; head: Coord<Geometry.CELL>; tail: Coord<Geometry.CELL> };
-    function getItems(items: null | Record<string, ArrayObj<Idx<Geometry.CELL>>>): Item[] {
-        if (null == items) return [];
-        const out: Item[] = [];
-        for (const [itemId, idxArrObj] of Object.entries(items)) {
-            const idxArr = arrayObj2array(idxArrObj);
-            out.push({
-                head: cellIdx2cellCoord(idxArr[0], grid),
-                tail: cellIdx2cellCoord(idxArr[idxArr.length - 1], grid),
-                itemId,
-                d: makePath(idxArr, grid, { shortenHead: bulbRadius, shortenTail: bulbRadius, bezierRounding: 0.2 }),
-            });
-        }
-        return out;
-    }
-    const items = derived(ref, getItems);
 </script>
 
 <mask id="between-{id}-mask" maskUnits="userSpaceOnUse" x="0" y="0" width={grid.width} height={grid.height}>
     <rect width={grid.width} height={grid.height} fill="#fff" />
 </mask>
 <g {id}>
-    {#each $items as { itemId, d, head, tail } (itemId)}
+    {#each Object.entries($ref || {}) as [itemId, idxArrObj] (itemId)}
+        {@const idxArr = arrayObj2array(idxArrObj)}
+        {@const head = cellIdx2cellCoord(idxArr[0], grid)}
+        {@const tail = cellIdx2cellCoord(idxArr[idxArr.length - 1], grid)}
+        {@const d = makePath(idxArr, grid, { shortenHead: bulbRadius, shortenTail: bulbRadius, bezierRounding: 0.2 })}
         <path
             {d}
             fill="none"

--- a/packages/board/src/lib/svelte/CenterRender.svelte
+++ b/packages/board/src/lib/svelte/CenterRender.svelte
@@ -38,7 +38,7 @@
             lengthAdjust="spacingAndGlyphs"
         >
             {#each keys as key}
-                <tspan fill={color(nums![key])}>{key}</tspan>
+                <tspan fill={color(nums[key])}>{key}</tspan>
             {/each}
         </text>
     {/each}

--- a/packages/board/src/lib/svelte/CenterRender.svelte
+++ b/packages/board/src/lib/svelte/CenterRender.svelte
@@ -1,24 +1,9 @@
 <script lang="ts">
-    import type { Geometry, Idx, IdxMap } from '@sudoku-studio/schema';
+    import type { Grid, schema } from '@sudoku-studio/schema';
     import { idxMapToKeysArray, cellIdx2cellCoord } from '@sudoku-studio/board-utils/src';
     import type { StateRef } from '@sudoku-studio/state-manager/src';
 
-    export let id: string;
-    export let ref: StateRef;
-    export let grid: { width: number; height: number };
-
-    function getMarks(
-        cells: IdxMap<Geometry.CELL, Record<string, number>>,
-    ): { idx: number; x: number; y: number; keys: Idx<Geometry.CELL>[]; nums: Record<string, number> }[] {
-        const out: { idx: number; x: number; y: number; keys: Idx<Geometry.CELL>[]; nums: Record<string, number> }[] =
-            [];
-        for (const [idx, nums] of Object.entries(cells)) {
-            const [x, y] = cellIdx2cellCoord(+idx, grid).map((x) => x + 0.5);
-            out.push({ idx: +idx, x, y, keys: idxMapToKeysArray(nums), nums: nums || {} });
-        }
-
-        return out;
-    }
+    const { id, ref, grid }: { id: string; ref: StateRef<schema.PencilMarksElement['value']>; grid: Grid } = $props();
 
     /// This function determines the color based on the count of numbers.
     /// `count` is a `true` when center marks are entered manually.
@@ -39,7 +24,9 @@
 </script>
 
 <g {id} mask="url(#SUDOKU_MASK_GIVENS_FILLED)">
-    {#each getMarks($ref || {}) as { idx, x, y, keys, nums } (idx)}
+    {#each Object.entries($ref || {}) as [cellIdx, nums] (cellIdx)}
+        {@const [x, y] = cellIdx2cellCoord(+cellIdx, grid).map((z) => z + 0.5)}
+        {@const keys = idxMapToKeysArray(nums)}
         <text
             {x}
             {y}
@@ -51,7 +38,7 @@
             lengthAdjust="spacingAndGlyphs"
         >
             {#each keys as key}
-                <tspan fill={color(nums[key])}>{key}</tspan>
+                <tspan fill={color(nums![key])}>{key}</tspan>
             {/each}
         </text>
     {/each}

--- a/packages/board/src/lib/svelte/CloneRender.svelte
+++ b/packages/board/src/lib/svelte/CloneRender.svelte
@@ -1,11 +1,9 @@
 <script lang="ts">
     import { getBorderPath, cellIdx2cellCoord, arrayObj2array } from '@sudoku-studio/board-utils/src';
-    import type { schema } from '@sudoku-studio/schema';
+    import type { Grid, schema } from '@sudoku-studio/schema';
     import type { StateRef } from '@sudoku-studio/state-manager/src';
 
-    export let id: string;
-    export let ref: StateRef;
-    export let grid: { width: number; height: number };
+    const { id, ref, grid }: { id: string; ref: StateRef<schema.CloneElement['value']>; grid: Grid } = $props();
 
     const inset = 0.05;
     const fontSize = 0.2;

--- a/packages/board/src/lib/svelte/ColorsRender.svelte
+++ b/packages/board/src/lib/svelte/ColorsRender.svelte
@@ -1,12 +1,10 @@
 <script lang="ts">
-    import type { Geometry, IdxMap } from '@sudoku-studio/schema';
+    import type { Geometry, Grid, IdxMap, schema } from '@sudoku-studio/schema';
     import { makeConicalCellSlice } from '@sudoku-studio/board-utils/src';
     import type { StateRef } from '@sudoku-studio/state-manager/src';
     import hsluv from 'hsluv';
 
-    export let id: string;
-    export let ref: StateRef;
-    export let grid: { width: number; height: number };
+    const { id, ref, grid }: { id: string; ref: StateRef<schema.ColorsElement['value']>; grid: Grid } = $props();
 
     type Item = { idx: number; slices: { d: string; fill: string }[] };
     function getMarks(cells: IdxMap<Geometry.CELL, Record<string, boolean>>): Item[] {

--- a/packages/board/src/lib/svelte/CornerRender.svelte
+++ b/packages/board/src/lib/svelte/CornerRender.svelte
@@ -1,21 +1,18 @@
 <script lang="ts">
-    import type { Geometry, IdxMap } from '@sudoku-studio/schema';
+    import type { Grid, schema } from '@sudoku-studio/schema';
     import { idxMapToKeysArray, cellIdx2cellCoord, cornerMarkPos } from '@sudoku-studio/board-utils/src';
     import type { StateRef } from '@sudoku-studio/state-manager/src';
 
-    export let id: string;
-    export let ref: StateRef;
-    export let grid: { width: number; height: number };
+    const { id, ref, grid }: { id: string; ref: StateRef<schema.PencilMarksElement['value']>; grid: Grid } = $props();
 
-    function getMarks(
-        cells: IdxMap<Geometry.CELL, true | Record<string, boolean>>,
-    ): { idx: number; nums: { x: number; y: number; num: number }[] }[] {
-        const out: { idx: number; nums: { x: number; y: number; num: number }[] }[] = [];
-        for (const [idx, numsBitset] of Object.entries(cells)) {
+    type Item = { idx: number; nums: { x: number; y: number; num: number }[] };
+    function getMarks(cells: schema.PencilMarksElement['value']): Item[] {
+        const out: Item[] = [];
+        for (const [idx, numsBitset] of Object.entries(cells || {})) {
             const x = cellIdx2cellCoord(+idx, grid)[0] + 0.5;
             const y = cellIdx2cellCoord(+idx, grid)[1] + 0.5;
             const nums =
-                true === numsBitset
+                typeof numsBitset !== 'object'
                     ? []
                     : idxMapToKeysArray(numsBitset).map((num, i, arr) => {
                           const [dx, dy] = cornerMarkPos(i, arr.length);

--- a/packages/board/src/lib/svelte/CursorRender.svelte
+++ b/packages/board/src/lib/svelte/CursorRender.svelte
@@ -1,20 +1,19 @@
 <script lang="ts">
     import { derived } from 'svelte/store';
-
     import { cellIdx2cellCoord } from '@sudoku-studio/board-utils/src';
     import type { StateRef } from '@sudoku-studio/state-manager/src';
+    import type { Grid, user } from '@sudoku-studio/schema';
 
-    export let id: string;
-    export let ref: StateRef;
-    export let grid: { width: number; height: number };
+    const { id, ref, grid }: { id: string; ref: StateRef<user.UserState['cursor']>; grid: Grid } = $props();
 
     const fill = '#08f';
     const cursorSize = 0.2;
 
     const dCursor = derived(ref, (cursorState) => {
+        if (null == cursorState) return '';
         const { index, isShown } = cursorState;
 
-        if (!isShown) return '';
+        if (!isShown || null == index) return '';
         const [x, y] = cellIdx2cellCoord(index, grid);
         return `M${x},${y}L${x + cursorSize},${y}L${x},${y + cursorSize}Z`;
     });

--- a/packages/board/src/lib/svelte/DiagonalRender.svelte
+++ b/packages/board/src/lib/svelte/DiagonalRender.svelte
@@ -1,9 +1,8 @@
 <script lang="ts">
+    import type { Grid, schema } from '@sudoku-studio/schema';
     import type { StateRef } from '@sudoku-studio/state-manager/src';
 
-    export let id: string;
-    export let ref: StateRef;
-    export let grid: { width: number; height: number };
+    const { id, ref, grid }: { id: string; ref: StateRef<schema.DiagonalElement['value']>; grid: Grid } = $props();
 
     const positive = ref.ref('positive');
     const negative = ref.ref('negative');

--- a/packages/board/src/lib/svelte/DigitRender.svelte
+++ b/packages/board/src/lib/svelte/DigitRender.svelte
@@ -1,20 +1,28 @@
 <script lang="ts">
     import { cellIdx2cellCoord } from '@sudoku-studio/board-utils/src';
+    import type { Grid, schema } from '@sudoku-studio/schema';
     import type { StateRef } from '@sudoku-studio/state-manager/src';
 
-    export let id: string;
-    export let ref: StateRef;
-    export let grid: { width: number; height: number };
-
-    export let color: string = '#000';
-    export let mask: string | undefined = undefined;
+    const {
+        id,
+        ref,
+        grid,
+        color = '#000',
+        mask = undefined,
+    }: {
+        id: string;
+        ref: StateRef<schema.DigitElement['value']>;
+        grid: Grid;
+        color?: string;
+        mask?: string;
+    } = $props();
 </script>
 
 <g {id} {mask}>
-    {#each Object.entries($ref || {}) as [idx, num] (idx)}
+    {#each Object.entries($ref || {}) as [cellIdx, num] (cellIdx)}
         <text
-            x={cellIdx2cellCoord(+idx, grid)[0] + 0.5}
-            y={cellIdx2cellCoord(+idx, grid)[1] + 0.5}
+            x={cellIdx2cellCoord(+cellIdx, grid)[0] + 0.5}
+            y={cellIdx2cellCoord(+cellIdx, grid)[1] + 0.5}
             fill={color}
             text-anchor="middle"
             dominant-baseline="central"

--- a/packages/board/src/lib/svelte/DoubleArrowRender.svelte
+++ b/packages/board/src/lib/svelte/DoubleArrowRender.svelte
@@ -1,40 +1,24 @@
 <script lang="ts">
-    import type { ArrayObj, Coord, Geometry, Idx } from '@sudoku-studio/schema';
+    import type { Grid, schema } from '@sudoku-studio/schema';
     import type { StateRef } from '@sudoku-studio/state-manager/src';
     import { makePath, arrayObj2array, cellIdx2cellCoord } from '@sudoku-studio/board-utils/src';
-    import { derived } from 'svelte/store';
 
-    export let id: string;
-    export let ref: StateRef;
-    export let grid: { width: number; height: number };
+    const { id, ref, grid }: { id: string; ref: StateRef<schema.LineElement['value']>; grid: Grid } = $props();
 
     const bulbRadius = 0.375;
     const outlineWidth = 0.025;
     const strokeWidth = 0.15;
-
-    type Item = { itemId: string; d: string; head: Coord<Geometry.CELL>; tail: Coord<Geometry.CELL> };
-    function getItems(items: null | Record<string, ArrayObj<Idx<Geometry.CELL>>>): Item[] {
-        if (null == items) return [];
-        const out: Item[] = [];
-        for (const [itemId, idxArrObj] of Object.entries(items)) {
-            const idxArr = arrayObj2array(idxArrObj);
-            out.push({
-                head: cellIdx2cellCoord(idxArr[0], grid),
-                tail: cellIdx2cellCoord(idxArr[idxArr.length - 1], grid),
-                itemId,
-                d: makePath(idxArr, grid, { shortenHead: bulbRadius, shortenTail: bulbRadius, bezierRounding: 0.2 }),
-            });
-        }
-        return out;
-    }
-    const items = derived(ref, getItems);
 </script>
 
 <mask id="double-arrow-{id}-mask" maskUnits="userSpaceOnUse" x="0" y="0" width={grid.width} height={grid.height}>
     <rect width={grid.width} height={grid.height} fill="#fff" />
 </mask>
 <g {id}>
-    {#each $items as { itemId, d, head, tail } (itemId)}
+    {#each Object.entries($ref || {}) as [itemId, idxArrObj] (itemId)}
+        {@const idxArr = arrayObj2array(idxArrObj)}
+        {@const head = cellIdx2cellCoord(idxArr[0], grid)}
+        {@const tail = cellIdx2cellCoord(idxArr[idxArr.length - 1], grid)}
+        {@const d = makePath(idxArr, grid, { shortenHead: bulbRadius, shortenTail: bulbRadius, bezierRounding: 0.2 })}
         <path
             {d}
             fill="none"

--- a/packages/board/src/lib/svelte/EvenRender.svelte
+++ b/packages/board/src/lib/svelte/EvenRender.svelte
@@ -1,30 +1,17 @@
 <script lang="ts">
-    import { idxMapToKeysArray } from '@sudoku-studio/board-utils/src';
-    import { cellIdx2cellCoord } from '@sudoku-studio/board-utils/src';
-
-    import type { Idx, Geometry, schema } from '@sudoku-studio/schema';
+    import { cellIdx2cellCoord, idxMapToKeysArray } from '@sudoku-studio/board-utils/src';
+    import type { schema, Grid } from '@sudoku-studio/schema';
     import type { StateRef } from '@sudoku-studio/state-manager/src';
 
-    export let id: string;
-    export let ref: StateRef;
-    export let grid: { width: number; height: number };
+    const { id, ref, grid }: { id: string; ref: StateRef<schema.RegionElement['value']>; grid: Grid } = $props();
 
     const margin = 0.125;
     const size = 1 - 2 * margin;
-
-    type Item = { idx: Idx<Geometry.CELL>; x: number; y: number };
-    function each(value: schema.RegionElement['value']): Item[] {
-        const out: Item[] = [];
-        for (const cellIdx of idxMapToKeysArray(value)) {
-            const [x, y] = cellIdx2cellCoord(cellIdx, grid);
-            out.push({ idx: +cellIdx, x: x + margin, y: y + margin });
-        }
-        return out;
-    }
 </script>
 
 <g {id}>
-    {#each each($ref || {}) as { idx, x, y } (idx)}
-        <rect {x} {y} width={size} height={size} fill="#666" fill-opacity="0.267" />
+    {#each idxMapToKeysArray($ref) as cellIdx (cellIdx)}
+        {@const [x, y] = cellIdx2cellCoord(+cellIdx, grid)}
+        <rect x={x + margin} y={y + margin} width={size} height={size} fill="#666" fill-opacity="0.267" />
     {/each}
 </g>

--- a/packages/board/src/lib/svelte/GridRegionRender.svelte
+++ b/packages/board/src/lib/svelte/GridRegionRender.svelte
@@ -5,25 +5,17 @@
         idxMapToKeysArray,
         GRID_REGION_THICKNESS,
     } from '@sudoku-studio/board-utils/src';
-    import type { ArrayObj, Geometry, IdxBitset } from '@sudoku-studio/schema';
+    import type { Grid, schema } from '@sudoku-studio/schema';
     import type { StateRef } from '@sudoku-studio/state-manager/src';
 
-    export let id: string;
-    export let ref: StateRef; // schema.GridRegionElement
-    export let grid: { width: number; height: number };
-
-    function each(regions: ArrayObj<IdxBitset<Geometry.CELL>>): string[] {
-        function isNonEmptyString(s: string | null): s is string {
-            return s != null && s.length > 0;
-        }
-        return arrayObj2array(regions)
-            .map((r) => getBorderPath(idxMapToKeysArray(r), grid, 0, false))
-            .filter(isNonEmptyString);
-    }
+    const { id, ref, grid }: { id: string; ref: StateRef<schema.GridRegionElement['value']>; grid: Grid } = $props();
 </script>
 
 <g {id}>
-    {#each each($ref) as d}
-        <path {d} fill="none" stroke="#000" stroke-width={GRID_REGION_THICKNESS} />
+    {#each arrayObj2array($ref || {}) as region, i (i)}
+        {@const d = getBorderPath(idxMapToKeysArray(region), grid, 0, false)}
+        {#if d != null && 0 < d.length}
+            <path {d} fill="none" stroke="#000" stroke-width={GRID_REGION_THICKNESS} />
+        {/if}
     {/each}
 </g>

--- a/packages/board/src/lib/svelte/GridRender.svelte
+++ b/packages/board/src/lib/svelte/GridRender.svelte
@@ -1,13 +1,9 @@
 <script lang="ts">
     import { GRID_THICKNESS, GRID_THICKNESS_HALF } from '@sudoku-studio/board-utils/src';
+    import type { Grid } from '@sudoku-studio/schema';
     import type { StateRef } from '@sudoku-studio/state-manager/src';
 
-    export let id: string;
-    export let ref: StateRef;
-    export let grid: { width: number; height: number };
-
-    // @ts-ignore
-    const _ = ref; // Unused.
+    const { id, ref: _, grid }: { id: string; ref: StateRef<null>; grid: Grid } = $props();
 </script>
 
 <pattern id="grid-{id}" width="1" height="1" patternUnits="userSpaceOnUse">

--- a/packages/board/src/lib/svelte/IndexerRender.svelte
+++ b/packages/board/src/lib/svelte/IndexerRender.svelte
@@ -2,34 +2,27 @@
     import { idxMapToKeysArray } from '@sudoku-studio/board-utils/src';
     import { cellIdx2cellCoord } from '@sudoku-studio/board-utils/src';
 
-    import type { Idx, Geometry, schema } from '@sudoku-studio/schema';
+    import type { Idx, Geometry, schema, Grid } from '@sudoku-studio/schema';
     import type { StateRef } from '@sudoku-studio/state-manager/src';
 
-    export let id: string;
-    export let ref: StateRef;
-    export let grid: { width: number; height: number };
-    export let color: string;
+    const {
+        id,
+        ref,
+        grid,
+        color,
+    }: { id: string; ref: StateRef<schema.RegionElement['value']>; grid: Grid; color: string } = $props();
 
     const margin = 0.025;
     const stroke = 2 * margin;
     const size = 1 - stroke;
-
-    type Item = { idx: Idx<Geometry.CELL>; x: number; y: number };
-    function each(value: schema.RegionElement['value']): Item[] {
-        const out: Item[] = [];
-        for (const cellIdx of idxMapToKeysArray(value)) {
-            const [x, y] = cellIdx2cellCoord(cellIdx, grid);
-            out.push({ idx: +cellIdx, x: x + margin, y: y + margin });
-        }
-        return out;
-    }
 </script>
 
 <g {id}>
-    {#each each($ref || {}) as { idx, x, y } (idx)}
+    {#each idxMapToKeysArray($ref) as cellIdx (cellIdx)}
+        {@const [x, y] = cellIdx2cellCoord(cellIdx, grid)}
         <rect
-            {x}
-            {y}
+            x={x + margin}
+            y={y + margin}
             width={size}
             height={size}
             stroke={color}

--- a/packages/board/src/lib/svelte/KillerRender.svelte
+++ b/packages/board/src/lib/svelte/KillerRender.svelte
@@ -1,11 +1,9 @@
 <script lang="ts">
     import { idxMapToKeysArray, getBorderPath, cellIdx2cellCoord } from '@sudoku-studio/board-utils/src';
-    import type { Geometry, schema } from '@sudoku-studio/schema';
+    import type { Geometry, Grid, schema } from '@sudoku-studio/schema';
     import type { StateRef } from '@sudoku-studio/state-manager/src';
 
-    export let id: string;
-    export let ref: StateRef;
-    export let grid: { width: number; height: number };
+    const { id, ref, grid }: { id: string; ref: StateRef<schema.KillerElement['value']>; grid: Grid } = $props();
 
     const inset = 0.075;
     const fontSize = 0.2;

--- a/packages/board/src/lib/svelte/LineRender.svelte
+++ b/packages/board/src/lib/svelte/LineRender.svelte
@@ -1,25 +1,27 @@
 <script lang="ts">
-    import type { ArrayObj, Geometry, Idx } from '@sudoku-studio/schema';
+    import type { ArrayObj, Geometry, Grid, Idx, schema } from '@sudoku-studio/schema';
     import type { StateRef } from '@sudoku-studio/state-manager/src';
     import type { MakePathOptions } from '@sudoku-studio/board-utils/src';
     import { makePath, arrayObj2array } from '@sudoku-studio/board-utils/src';
 
-    export let id: string;
-    export let ref: StateRef;
-    export let grid: { width: number; height: number };
-
-    export let stroke = '#c7855c';
-    export let strokeWidth = 0.125;
-
-    export let pathOptions: MakePathOptions = {
-        shortenHead: 0.2,
-        shortenTail: 0.2,
-        bezierRounding: 0.2,
-        closeLoops: false,
-    };
+    const {
+        id,
+        ref,
+        grid,
+        stroke = '#c7855c',
+        strokeWidth = 0.125,
+        pathOptions = { shortenHead: 0.2, shortenTail: 0.2, bezierRounding: 0.2, closeLoops: false },
+    }: {
+        id: string;
+        ref: StateRef<schema.LineElement['value']>;
+        grid: Grid;
+        stroke?: string;
+        strokeWidth?: number;
+        pathOptions?: MakePathOptions;
+    } = $props();
 
     type Item = { itemId: string; d: string };
-    function each(items: null | Record<string, ArrayObj<Idx<Geometry.CELL>>>): Item[] {
+    function each(items: schema.LineElement['value'] | null): Item[] {
         if (null == items) return [];
         const out: Item[] = [];
         for (const [itemId, idxArrObj] of Object.entries(items)) {

--- a/packages/board/src/lib/svelte/LittleKillerRender.svelte
+++ b/packages/board/src/lib/svelte/LittleKillerRender.svelte
@@ -1,12 +1,10 @@
 <script lang="ts">
     import { diagonalIdx2dirVec, diagonalIdx2svgCoord } from '@sudoku-studio/board-utils/src';
 
-    import type { Idx, Geometry, schema } from '@sudoku-studio/schema';
+    import type { schema, Grid } from '@sudoku-studio/schema';
     import type { StateRef } from '@sudoku-studio/state-manager/src';
 
-    export let id: string;
-    export let ref: StateRef;
-    export let grid: { width: number; height: number };
+    const { id, ref, grid }: { id: string; ref: StateRef<schema.LittleKillerElement['value']>; grid: Grid } = $props();
 
     const color: string = '#000';
     const fontSize = 0.4;
@@ -15,24 +13,6 @@
 
     const arrowStart = 0.48 * fontSize;
     const arrowEnd = arrowStart + 0.15;
-
-    type Item = { idx: Idx<Geometry.EDGE>; x: number; y: number; text: string; d: string };
-    function each(value: schema.SeriesNumberElement['value']): Item[] {
-        const out: Item[] = [];
-        for (const [diagIdx, digitOrTrue] of Object.entries(value || {})) {
-            const text = true !== digitOrTrue ? `${digitOrTrue}` : '_';
-            const [x, y] = diagonalIdx2svgCoord(+diagIdx, grid, -0.9);
-            const vec = diagonalIdx2dirVec(+diagIdx);
-            out.push({
-                idx: +diagIdx,
-                x,
-                y,
-                text,
-                d: `M${x + arrowStart * vec[0]},${y + arrowStart * vec[1]}L${x + arrowEnd * vec[0]},${y + arrowEnd * vec[1]}`,
-            });
-        }
-        return out;
-    }
 </script>
 
 <marker
@@ -48,7 +28,11 @@
     <path d="M 0.4,0.425 L 0.5,0.5 L 0.4,0.575" fill="none" stroke={color} stroke-width={strokeWidth} />
 </marker>
 <g {id}>
-    {#each each($ref || {}) as { idx, x, y, text, d } (idx)}
+    {#each Object.entries($ref || {}) as [diagIdx, digitOrTrue] (diagIdx)}
+        {@const text = true !== digitOrTrue ? `${digitOrTrue}` : '_'}
+        {@const [x, y] = diagonalIdx2svgCoord(+diagIdx, grid, -0.9)}
+        {@const vec = diagonalIdx2dirVec(+diagIdx)}
+        {@const d = `M${x + arrowStart * vec[0]},${y + arrowStart * vec[1]}L${x + arrowEnd * vec[0]},${y + arrowEnd * vec[1]}`}
         <path {d} stroke={color} stroke-width={strokeWidth} marker-end="url(#lk-arrow-{id})" />
         <text
             {x}

--- a/packages/board/src/lib/svelte/LockoutRender.svelte
+++ b/packages/board/src/lib/svelte/LockoutRender.svelte
@@ -1,12 +1,9 @@
 <script lang="ts">
-    import type { ArrayObj, Coord, Geometry, Idx } from '@sudoku-studio/schema';
+    import type { Grid, schema } from '@sudoku-studio/schema';
     import type { StateRef } from '@sudoku-studio/state-manager/src';
     import { makePath, arrayObj2array, cellIdx2cellCoord } from '@sudoku-studio/board-utils/src';
-    import { derived } from 'svelte/store';
 
-    export let id: string;
-    export let ref: StateRef;
-    export let grid: { width: number; height: number };
+    const { id, ref, grid }: { id: string; ref: StateRef<schema.LineElement['value']>; grid: Grid } = $props();
 
     const diamondSize = 0.65;
     const diamondOffset = (1 - diamondSize) / 2;
@@ -16,34 +13,21 @@
     const diamondOutline = '#0000ff';
     const diamondFill = '#e7e6ff';
     const lineColor = '#aabeef';
-
-    type Item = { itemId: string; d: string; head: Coord<Geometry.CELL>; tail: Coord<Geometry.CELL> };
-    function getItems(items: null | Record<string, ArrayObj<Idx<Geometry.CELL>>>): Item[] {
-        if (null == items) return [];
-        const out: Item[] = [];
-        for (const [itemId, idxArrObj] of Object.entries(items)) {
-            const idxArr = arrayObj2array(idxArrObj);
-            out.push({
-                head: cellIdx2cellCoord(idxArr[0], grid),
-                tail: cellIdx2cellCoord(idxArr[idxArr.length - 1], grid),
-                itemId,
-                d: makePath(idxArr, grid, {
-                    shortenHead: diamondSize / 2,
-                    shortenTail: diamondSize / 2,
-                    bezierRounding: 0.3,
-                }),
-            });
-        }
-        return out;
-    }
-    const items = derived(ref, getItems);
 </script>
 
 <mask id="lockout-{id}-mask" maskUnits="userSpaceOnUse" x="0" y="0" width={grid.width} height={grid.height}>
     <rect width={grid.width} height={grid.height} fill="#fff" />
 </mask>
 <g {id}>
-    {#each $items as { itemId, d, head, tail } (itemId)}
+    {#each Object.entries($ref || {}) as [itemId, idxArrayObj] (itemId)}
+        {@const idxArr = arrayObj2array(idxArrayObj)}
+        {@const head = cellIdx2cellCoord(idxArr[0], grid)}
+        {@const tail = cellIdx2cellCoord(idxArr[idxArr.length - 1], grid)}
+        {@const d = makePath(idxArr, grid, {
+            shortenHead: diamondSize / 2,
+            shortenTail: diamondSize / 2,
+            bezierRounding: 0.3,
+        })}
         <path
             {d}
             fill="none"

--- a/packages/board/src/lib/svelte/MaxRender.svelte
+++ b/packages/board/src/lib/svelte/MaxRender.svelte
@@ -1,13 +1,12 @@
 <script lang="ts">
     import { cellIdx2cellCoord } from '@sudoku-studio/board-utils/src';
+    import type { Grid, schema } from '@sudoku-studio/schema';
     import type { StateRef } from '@sudoku-studio/state-manager/src';
 
-    export let id: string;
-    export let ref: StateRef;
-    export let grid: { width: number; height: number };
+    const { id, ref, grid }: { id: string; ref: StateRef<schema.RegionElement['value']>; grid: Grid } = $props();
 </script>
 
-<!-- Path for <>. -->
+<!-- Path for `<>`. -->
 <path
     id="max-{id}"
     d="M 0.12,0.38 L 0.08,0.50 L 0.12,0.62 M 0.38,0.12 L 0.50,0.08 L 0.62,0.12 M 0.88,0.62 L 0.92,0.50 L 0.88,0.38 M 0.62,0.88 L 0.50,0.92 L 0.38,0.88"
@@ -30,22 +29,22 @@
 >
     <!-- Mask out board edges. -->
     <rect x="0.25" y="0.25" width={grid.width - 0.5} height={grid.height - 0.5} fill="#fff" />
-    {#each Object.entries($ref || {}) as [idx, _true] (idx)}
+    {#each Object.entries($ref || {}) as [cellIdx, _true] (cellIdx)}
         <!-- Mask for each cell. -->
         <use
             href="#max-{id}-maskitem"
-            transform="translate({cellIdx2cellCoord(+idx, grid)[0]},{cellIdx2cellCoord(+idx, grid)[1]})"
+            transform="translate({cellIdx2cellCoord(+cellIdx, grid)[0]},{cellIdx2cellCoord(+cellIdx, grid)[1]})"
             fill="#000"
         />
     {/each}
 </mask>
 <rect width={grid.width} height={grid.height} fill="#fff" />
 <g {id}>
-    {#each Object.entries($ref || {}) as [idx, _true] (idx)}
+    {#each Object.entries($ref || {}) as [cellIdx, _true] (cellIdx)}
         <!-- Background color. -->
         <rect
-            x={cellIdx2cellCoord(+idx, grid)[0]}
-            y={cellIdx2cellCoord(+idx, grid)[1]}
+            x={cellIdx2cellCoord(+cellIdx, grid)[0]}
+            y={cellIdx2cellCoord(+cellIdx, grid)[1]}
             width="1"
             height="1"
             fill="#7d3737"
@@ -53,11 +52,11 @@
         />
     {/each}
     <g mask="url(#max-{id}-mask)">
-        {#each Object.entries($ref || {}) as [idx, _true] (idx)}
+        {#each Object.entries($ref || {}) as [cellIdx, _true] (cellIdx)}
             <!-- Each <> cell -->
             <use
                 href="#max-{id}"
-                transform="translate({cellIdx2cellCoord(+idx, grid)[0]},{cellIdx2cellCoord(+idx, grid)[1]})"
+                transform="translate({cellIdx2cellCoord(+cellIdx, grid)[0]},{cellIdx2cellCoord(+cellIdx, grid)[1]})"
             />
         {/each}
     </g>

--- a/packages/board/src/lib/svelte/MinRender.svelte
+++ b/packages/board/src/lib/svelte/MinRender.svelte
@@ -1,13 +1,12 @@
 <script lang="ts">
     import { cellIdx2cellCoord } from '@sudoku-studio/board-utils/src';
+    import type { Grid, schema } from '@sudoku-studio/schema';
     import type { StateRef } from '@sudoku-studio/state-manager/src';
 
-    export let id: string;
-    export let ref: StateRef;
-    export let grid: { width: number; height: number };
+    const { id, ref, grid }: { id: string; ref: StateRef<schema.RegionElement>; grid: Grid } = $props();
 </script>
 
-<!-- Path for ><. -->
+<!-- Path for `><`. -->
 <path
     id="min-{id}"
     d="M 0.08,0.38 L 0.12,0.50 L 0.08,0.62 M 0.38,0.08 L 0.50,0.12 L 0.62,0.08 M 0.92,0.62 L 0.88,0.50 L 0.92,0.38 M 0.62,0.92 L 0.50,0.88 L 0.38,0.92"
@@ -30,22 +29,22 @@
 >
     <!-- Mask out board edges. -->
     <rect x="0.25" y="0.25" width={grid.width - 0.5} height={grid.height - 0.5} fill="#fff" />
-    {#each Object.entries($ref || {}) as [idx, _true] (idx)}
+    {#each Object.entries($ref || {}) as [cellIdx, _true] (cellIdx)}
         <!-- Mask for each cell. -->
         <use
             href="#min-{id}-maskitem"
-            transform="translate({cellIdx2cellCoord(+idx, grid)[0]},{cellIdx2cellCoord(+idx, grid)[1]})"
+            transform="translate({cellIdx2cellCoord(+cellIdx, grid)[0]},{cellIdx2cellCoord(+cellIdx, grid)[1]})"
             fill="#000"
         />
     {/each}
 </mask>
 <rect width={grid.width} height={grid.height} fill="#fff" />
 <g {id}>
-    {#each Object.entries($ref || {}) as [idx, _true] (idx)}
+    {#each Object.entries($ref || {}) as [cellIdx, _true] (cellIdx)}
         <!-- Background color. -->
         <rect
-            x={cellIdx2cellCoord(+idx, grid)[0]}
-            y={cellIdx2cellCoord(+idx, grid)[1]}
+            x={cellIdx2cellCoord(+cellIdx, grid)[0]}
+            y={cellIdx2cellCoord(+cellIdx, grid)[1]}
             width="1"
             height="1"
             fill="#694b7d"
@@ -53,11 +52,11 @@
         />
     {/each}
     <g mask="url(#min-{id}-mask)">
-        {#each Object.entries($ref || {}) as [idx, _true] (idx)}
+        {#each Object.entries($ref || {}) as [cellIdx, _true] (cellIdx)}
             <!-- Each >< cell. -->
             <use
                 href="#min-{id}"
-                transform="translate({cellIdx2cellCoord(+idx, grid)[0]},{cellIdx2cellCoord(+idx, grid)[1]})"
+                transform="translate({cellIdx2cellCoord(+cellIdx, grid)[0]},{cellIdx2cellCoord(+cellIdx, grid)[1]})"
             />
         {/each}
     </g>

--- a/packages/board/src/lib/svelte/NullRender.svelte
+++ b/packages/board/src/lib/svelte/NullRender.svelte
@@ -1,10 +1,7 @@
 <script lang="ts">
+    import type { Grid } from '@sudoku-studio/schema';
     import type { StateRef } from '@sudoku-studio/state-manager/src';
 
-    export let id: string;
-    export let ref: StateRef;
-    export let grid: { width: number; height: number };
-
-    // @ts-ignore
-    const _ = [id, ref, grid]; // Unused.
+    const { id, ref, grid }: { id: string; ref: StateRef<any>; grid: Grid } = $props();
+    const _ = [id, ref, grid];
 </script>

--- a/packages/board/src/lib/svelte/OddRender.svelte
+++ b/packages/board/src/lib/svelte/OddRender.svelte
@@ -1,27 +1,15 @@
 <script lang="ts">
-    import { idxMapToKeysArray } from '@sudoku-studio/board-utils/src';
-    import { cellIdx2cellCoord } from '@sudoku-studio/board-utils/src';
-
-    import type { Idx, Geometry, schema } from '@sudoku-studio/schema';
+    import { cellIdx2cellCoord, idxMapToKeysArray } from '@sudoku-studio/board-utils/src';
+    import type { schema, Grid } from '@sudoku-studio/schema';
     import type { StateRef } from '@sudoku-studio/state-manager/src';
 
-    export let id: string;
-    export let ref: StateRef;
-    export let grid: { width: number; height: number };
-
-    type Item = { idx: Idx<Geometry.CELL>; cx: number; cy: number };
-    function each(value: schema.RegionElement['value']): Item[] {
-        const out: Item[] = [];
-        for (const cellIdx of idxMapToKeysArray(value)) {
-            const [x, y] = cellIdx2cellCoord(cellIdx, grid);
-            out.push({ idx: +cellIdx, cx: x + 0.5, cy: y + 0.5 });
-        }
-        return out;
-    }
+    const { id, ref, grid }: { id: string; ref: StateRef<schema.RegionElement['value']>; grid: Grid } = $props();
+    const r = 0.425;
 </script>
 
 <g {id}>
-    {#each each($ref || {}) as { idx, cx, cy } (idx)}
-        <circle {cx} {cy} r="0.425" fill="#666" fill-opacity="0.267" />
+    {#each idxMapToKeysArray($ref) as cellIdx (cellIdx)}
+        {@const [x, y] = cellIdx2cellCoord(+cellIdx, grid)}
+        <circle cx={x + 0.5} cy={y + 0.5} {r} fill="#666" fill-opacity="0.267" />
     {/each}
 </g>

--- a/packages/board/src/lib/svelte/PositionNumberRender.svelte
+++ b/packages/board/src/lib/svelte/PositionNumberRender.svelte
@@ -1,38 +1,44 @@
-<script lang="ts">
-    import type { Idx, Geometry, schema, Grid, Coord } from '@sudoku-studio/schema';
+<script lang="ts" module>
+    import type { Idx, Geometry, Grid, Coord, IdxMap } from '@sudoku-studio/schema';
     import type { StateRef } from '@sudoku-studio/state-manager/src';
 
-    export let id: string;
-    export let ref: StateRef;
-    export let grid: { width: number; height: number };
+    export type Props = {
+        id: string;
+        ref: StateRef<IdxMap<Geometry, true | number> | null>;
+        grid: Grid;
+        idx2coord: (idx: Idx<Geometry>, grid: Grid) => Coord<any>;
+        stroke?: string;
+        fill?: string;
+        textColor?: string;
+        radius?: number;
+        strokeWidth?: number;
+        fontSize?: number;
+        fontWeight?: number;
+        mapDigits?: (num: true | number) => string;
+    };
+</script>
 
-    export let idx2coord: (idx: Idx<Geometry>, grid: Grid) => Coord<any>;
-
-    export let stroke: string = '#242424';
-    export let fill: string = '#fff';
-    export let textColor: string = '#000';
-
-    export let radius = 0.15;
-    export let strokeWidth = 0.02;
-    export let fontSize = 0.25;
-    export let fontWeight = 600;
-
-    export let mapDigits = (num: true | number): string => (true !== num ? `${num}` : '');
-
-    type Item = { idx: Idx<Geometry>; x: number; y: number; text: string };
-    function each(value: schema.SeriesNumberElement['value']): Item[] {
-        const out: Item[] = [];
-        for (const [idx, digitOrTrue] of Object.entries(value || {})) {
-            const text = mapDigits(digitOrTrue!);
-            const [x, y] = idx2coord(+idx, grid);
-            out.push({ idx: +idx, x, y, text });
-        }
-        return out;
-    }
+<script lang="ts">
+    const {
+        id,
+        ref,
+        grid,
+        idx2coord,
+        stroke = '#242424',
+        fill = '#fff',
+        textColor = '#000',
+        radius = 0.15,
+        strokeWidth = 0.02,
+        fontSize = 0.25,
+        fontWeight = 600,
+        mapDigits = (num: true | number): string => (true !== num ? `${num}` : ''),
+    }: Props = $props();
 </script>
 
 <g {id}>
-    {#each each($ref || {}) as { idx, x, y, text } (idx)}
+    {#each Object.entries($ref || {}) as [idx, digitOrTrue] (idx)}
+        {@const text = mapDigits(digitOrTrue!)}
+        {@const [x, y] = idx2coord(+idx, grid)}
         {#if 0 < radius}
             <circle cx={x} cy={y} r={radius} {fill} {stroke} stroke-width={strokeWidth} />
         {/if}

--- a/packages/board/src/lib/svelte/QuadrupleRender.svelte
+++ b/packages/board/src/lib/svelte/QuadrupleRender.svelte
@@ -1,11 +1,9 @@
 <script lang="ts">
     import { arrayObj2array, cornerIdx2cornerCoord } from '@sudoku-studio/board-utils/src';
-    import type { schema } from '@sudoku-studio/schema';
+    import type { Grid, schema } from '@sudoku-studio/schema';
     import type { StateRef } from '@sudoku-studio/state-manager/src';
 
-    export let id: string;
-    export let ref: StateRef;
-    export let grid: { width: number; height: number };
+    const { id, ref, grid }: { id: string; ref: StateRef<schema.QuadrupleElement['value']>; grid: Grid } = $props();
 
     const radius = 0.2125;
     const strokeWidth = 0.02;

--- a/packages/board/src/lib/svelte/SelectRender.svelte
+++ b/packages/board/src/lib/svelte/SelectRender.svelte
@@ -1,22 +1,29 @@
 <script lang="ts">
-    import { derived } from 'svelte/store';
-
     import { getBorderPath, idxMapToKeysArray } from '@sudoku-studio/board-utils/src';
     import type { StateRef } from '@sudoku-studio/state-manager/src';
+    import type { Geometry, Grid, IdxBitset } from '@sudoku-studio/schema';
 
-    export let id: string;
-    export let ref: StateRef;
-    export let grid: { width: number; height: number };
+    const {
+        id,
+        ref,
+        grid,
+        fill = '#08f',
+        outlineOpacity = '#b2b2b2',
+        innerOpacity = '#080808',
+    }: {
+        id: string;
+        ref: StateRef<IdxBitset<Geometry.CELL>>;
+        grid: Grid;
+        fill?: string;
+        outlineOpacity?: string;
+        innerOpacity?: string;
+    } = $props();
 
     const inset = 0.075;
     const innerRadius = 0.05;
 
-    export let fill = '#08f';
-    export let outlineOpacity = '#b2b2b2';
-    export let innerOpacity = '#080808';
-
-    const dMask = derived(ref, (select) => getBorderPath(idxMapToKeysArray(select), grid, inset) || undefined);
-    const dFill = derived(ref, (select) => getBorderPath(idxMapToKeysArray(select), grid, 0) || undefined);
+    const dMask = $derived(getBorderPath(idxMapToKeysArray($ref), grid, inset) || undefined);
+    const dFill = $derived(getBorderPath(idxMapToKeysArray($ref), grid, 0) || undefined);
 </script>
 
 <filter id="select-{id}-blur">
@@ -30,6 +37,6 @@
 </filter>
 <mask id="select-{id}-mask" maskUnits="userSpaceOnUse" x="0" y="0" width={grid.width} height={grid.height}>
     <rect x="0" y="0" width={grid.width} height={grid.height} fill={outlineOpacity} />
-    <path d={$dMask} fill={innerOpacity} stroke="none" filter="url(#select-{id}-blur)" />
+    <path d={dMask} fill={innerOpacity} stroke="none" filter="url(#select-{id}-blur)" />
 </mask>
-<path {id} d={$dFill} {fill} stroke="none" mask="url(#select-{id}-mask)" />
+<path {id} d={dFill} {fill} stroke="none" mask="url(#select-{id}-mask)" />

--- a/packages/board/src/lib/svelte/ThermoRender.svelte
+++ b/packages/board/src/lib/svelte/ThermoRender.svelte
@@ -1,20 +1,22 @@
 <script lang="ts">
-    import type { ArrayObj, Geometry, Idx } from '@sudoku-studio/schema';
+    import type { ArrayObj, Geometry, Grid, Idx, schema } from '@sudoku-studio/schema';
     import type { StateRef } from '@sudoku-studio/state-manager/src';
     import { makePath, arrayObj2array } from '@sudoku-studio/board-utils/src';
 
-    export let id: string;
-    export let ref: StateRef;
-    export let grid: { width: number; height: number };
-    export let isSlow: boolean = false;
+    const {
+        id,
+        ref,
+        grid,
+        isSlow = false,
+    }: { id: string; ref: StateRef<schema.LineElement['value']>; grid: Grid; isSlow?: boolean } = $props();
 
     const bulbRadius = 0.375;
 
     export function getThermos(
-        thermos: Record<string, ArrayObj<Idx<Geometry.CELL>>>,
+        thermos: schema.LineElement['value'],
     ): { thermoId: string; d: string; invalid: boolean }[] {
         const out: { thermoId: string; d: string; invalid: boolean }[] = [];
-        for (const [thermoId, idxArrObj] of Object.entries(thermos)) {
+        for (const [thermoId, idxArrObj] of Object.entries(thermos || {})) {
             const idxArr = arrayObj2array(idxArrObj);
             out.push({
                 thermoId,
@@ -26,57 +28,63 @@
     }
 </script>
 
-<marker
-    id="thermo-bulb-{id}"
-    viewBox="0 0 1 1"
-    refX="0.5"
-    refY="0.5"
-    markerUnits="userSpaceOnUse"
-    markerWidth="1"
-    markerHeight="1"
-    orient="auto"
->
-    <circle cx="0.5" cy="0.5" r={bulbRadius} fill="#444" />
-</marker>
+{#if !isSlow}
+    <marker
+        id="thermo-bulb-{id}"
+        viewBox="0 0 1 1"
+        refX="0.5"
+        refY="0.5"
+        markerUnits="userSpaceOnUse"
+        markerWidth="1"
+        markerHeight="1"
+        orient="auto"
+    >
+        <circle cx="0.5" cy="0.5" r={bulbRadius} fill="#444" />
+    </marker>
+{:else}
+    <marker
+        id="slow-thermo-bulb-{id}"
+        viewBox="0 0 1 1"
+        refX="0.5"
+        refY="0.5"
+        markerUnits="userSpaceOnUse"
+        markerWidth="1"
+        markerHeight="1"
+        orient="auto"
+    >
+        <path
+            d="M0.35, 0.13 L0.65, 0.13 L0.86, 0.34 L0.86, 0.64 L0.64, 0.86 L0.35, 0.86 L0.13, 0.65 L0.13, 0.35 Z"
+            stroke="#444"
+            stroke-width="0.1"
+            fill="#222"
+        />
+    </marker>
 
-<marker
-    id="slow-thermo-bulb-{id}"
-    viewBox="0 0 1 1"
-    refX="0.5"
-    refY="0.5"
-    markerUnits="userSpaceOnUse"
-    markerWidth="1"
-    markerHeight="1"
-    orient="auto"
->
-    <path
-        d="M0.35, 0.13 L0.65, 0.13 L0.86, 0.34 L0.86, 0.64 L0.64, 0.86 L0.35, 0.86 L0.13, 0.65 L0.13, 0.35 Z"
-        stroke="#444"
-        stroke-width="0.1"
-        fill="#222"
-    />
-</marker>
-
-<marker
-    id="slow-thermo-endcap-{id}"
-    viewBox="0 0 1 1"
-    refX="0.5"
-    refY="0.5"
-    markerUnits="userSpaceOnUse"
-    markerWidth="1"
-    markerHeight="1"
->
-    <circle cx="0.5" cy="0.5" r="0.1" fill="#444" />
-</marker>
+    <marker
+        id="slow-thermo-endcap-{id}"
+        viewBox="0 0 1 1"
+        refX="0.5"
+        refY="0.5"
+        markerUnits="userSpaceOnUse"
+        markerWidth="1"
+        markerHeight="1"
+    >
+        <circle cx="0.5" cy="0.5" r="0.1" fill="#444" />
+    </marker>
+{/if}
 
 <mask id="thermo-{id}-mask" maskUnits="userSpaceOnUse" x="0" y="0" width={grid.width} height={grid.height}>
-    {#each getThermos($ref || {}) as { thermoId, d, invalid } (thermoId)}
+    {#each Object.entries($ref || {}) as [thermoId, idxArrObj] (thermoId)}
+        {@const idxArr = arrayObj2array(idxArrObj)}
+        {@const d = makePath(idxArr, grid, { shortenTail: 0.25, bezierRounding: 0.2 })}
+        {@const invalid = isSlow ? /* TODO(mingwei): check slow thermos too. */ false : idxArr.length > grid.width}
+        {@const stroke = invalid ? '#fff' : '#444'}
         {#if isSlow}
             <path {d} fill="none" stroke="#111" stroke-width="0.2" stroke-linejoin="round" />
             <path
                 {d}
                 fill="none"
-                stroke="#444"
+                {stroke}
                 stroke-width="0.2"
                 marker-start="url(#slow-thermo-bulb-{id})"
                 marker-end="url(#slow-thermo-endcap-{id})"
@@ -88,7 +96,7 @@
             <path
                 {d}
                 fill="none"
-                stroke={invalid && !isSlow ? '#fff' : '#444'}
+                {stroke}
                 stroke-width="0.2"
                 marker-start="url(#thermo-bulb-{id})"
                 stroke-linejoin="round"

--- a/packages/board/svelte.config.js
+++ b/packages/board/svelte.config.js
@@ -1,11 +1,21 @@
 import adapter from '@sveltejs/adapter-auto';
 import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
+import { join } from 'path';
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
     // Consult https://svelte.dev/docs/kit/integrations
     // for more information about preprocessors
-    preprocess: vitePreprocess(),
+    preprocess: vitePreprocess({
+        style: {
+            resolve: {
+                alias: {
+                    // https://github.com/sveltejs/language-tools/issues/1986#issuecomment-2317238374
+                    $lib: join(import.meta.dirname, 'src/lib'),
+                },
+            },
+        },
+    }),
 
     kit: {
         // adapter-auto only supports some environments, see https://svelte.dev/docs/kit/adapter-auto for a list.

--- a/packages/schema/schema.d.ts
+++ b/packages/schema/schema.d.ts
@@ -85,7 +85,7 @@ export declare namespace schema {
     export type ElementType = Element['type'];
 
     export interface AbstractElement {
-        type: Element['type'];
+        type: ElementType;
         order: number;
         value?: unknown;
     }

--- a/packages/schema/schema.d.ts
+++ b/packages/schema/schema.d.ts
@@ -7,7 +7,7 @@
 // `declare` creates the types without actually creating the variable values.
 // `unique symbol` is a _generative_ type -- even though it looks like CELL and CORNER
 // look like the same type, they are distinct and incompatible.
-export declare module Geometry {
+export declare namespace Geometry {
     const CELL: unique symbol;
     /** Grid cells -- where numbers go. */
     export type CELL = typeof CELL;
@@ -43,9 +43,9 @@ export type Idx<_TAG extends Geometry> = number;
 export type Coord<_TAG extends Geometry> = [x: number, y: number];
 /** JS Object map from Idx<TAG> to boolean flag representing set membership. */
 export type IdxBitset<TAG extends Geometry> = IdxMap<TAG, boolean>;
-/** JS Object map from Idx<TAG> to any value. */
+/** JS Object map from Idx<TAG> to a value `V`. */
 export type IdxMap<TAG extends Geometry, V> = { [K in Idx<TAG>]?: V };
-/** JS Object with numeric keys. A "stable array"; insertions/deletions do not change keys. */
+/** JS Object with numeric keys and values `V`. A "stable array"; insertions/deletions do not change keys. */
 export type ArrayObj<V> = { [K in number]: V };
 
 /** Width and height of the grid. */
@@ -104,7 +104,8 @@ export declare namespace schema {
     }
     export interface PencilMarksElement extends AbstractElement {
         type: 'corner' | 'center';
-        value?: IdxMap<Geometry.CELL, { [K: number]: true }>;
+        // Final value is either `true` or the number of occurances for that candidate digit.
+        value?: IdxMap<Geometry.CELL, { [K: number]: true | number }>;
     }
     export interface ColorsElement extends AbstractElement {
         type: 'colors';
@@ -133,6 +134,7 @@ export declare namespace schema {
             [K: string]: {
                 label?: string;
                 color?: string;
+                // TODO(mingwei): allow for more than two clones.
                 a?: ArrayObj<Idx<Geometry.CELL>>;
                 b?: ArrayObj<Idx<Geometry.CELL>>;
             };
@@ -145,27 +147,28 @@ export declare namespace schema {
     }
     export interface LineElement extends AbstractElement {
         type:
-            | 'thermo'
             | 'between'
             | 'doubleArrow'
+            | 'dutchWhisper'
             | 'lockout'
             | 'palindrome'
-            | 'whisper'
-            | 'dutchWhisper'
+            | 'regionSum'
             | 'renban'
-            | 'regionSum';
-        value?: { [K: string]: ArrayObj<Idx<Geometry.CELL>> };
+            | 'slowThermo'
+            | 'thermo'
+            | 'whisper';
+        value?: { [K: string]: LineElementItem };
     }
+    export type LineElementItem = ArrayObj<Idx<Geometry.CELL>>;
     export interface ArrowElement extends AbstractElement {
         type: 'arrow';
-        value?: {
-            [K: string]: {
-                bulb: ArrayObj<Idx<Geometry.CELL>>;
-                /** The first cell of the body is within the bulb and should not be considered for the sum. */
-                body: ArrayObj<Idx<Geometry.CELL>>;
-            };
-        };
+        value?: { [K: string]: ArrowElementItem };
     }
+    export type ArrowElementItem = {
+        bulb: ArrayObj<Idx<Geometry.CELL>>;
+        /** The first cell of the body is within the bulb and should not be considered for the sum. */
+        body: ArrayObj<Idx<Geometry.CELL>>;
+    };
     export interface EdgeNumberElement extends AbstractElement {
         type: 'difference' | 'ratio' | 'xv';
         value?: IdxMap<Geometry.EDGE, true | number>;

--- a/packages/schema/schema.d.ts
+++ b/packages/schema/schema.d.ts
@@ -44,7 +44,7 @@ export type Coord<_TAG extends Geometry> = [x: number, y: number];
 /** JS Object map from Idx<TAG> to boolean flag representing set membership. */
 export type IdxBitset<TAG extends Geometry> = IdxMap<TAG, boolean>;
 /** JS Object map from Idx<TAG> to a value `V`. */
-export type IdxMap<TAG extends Geometry, V> = { [K in Idx<TAG>]?: V };
+export type IdxMap<TAG extends Geometry, V> = { [K in Idx<TAG>]: V };
 /** JS Object with numeric keys and values `V`. A "stable array"; insertions/deletions do not change keys. */
 export type ArrayObj<V> = { [K in number]: V };
 

--- a/packages/state-manager/src/state-manager.ts
+++ b/packages/state-manager/src/state-manager.ts
@@ -34,7 +34,7 @@ function undefToNull<T>(val: T): null | NonNullable<T> | null {
     return val!;
 }
 
-export class StateRef<T extends Data = Data> {
+export class StateRef<T extends Data> {
     private readonly _stateManager: StateManager<any>;
     private readonly _path: string[] = [];
 
@@ -51,7 +51,7 @@ export class StateRef<T extends Data = Data> {
         return [...this._path];
     }
 
-    ref<U extends Data = Data>(...path: string[]): StateRef<U> {
+    ref<U extends Data>(...path: string[]): StateRef<U> {
         return new StateRef(this._stateManager, [...this._path, ...path]);
     }
 
@@ -79,11 +79,11 @@ export class StateRef<T extends Data = Data> {
     }
 
     // https://svelte.dev/docs#Store_contract
-    subscribe(subscription: (value: any) => void): () => void {
+    subscribe(subscription: (value: T | null) => void): () => void {
         const watch = this.watch((_path, _oldData, newData) => subscription(newData), true);
         return () => this.unwatch(watch);
     }
-    set(value: any) {
+    set(value: T | null) {
         this.replace(value);
     }
 }
@@ -95,7 +95,7 @@ export class StateRef<T extends Data = Data> {
 /// undo/redo diff to the caller.
 ///
 /// This is where the magic happens.
-export class StateManager<T extends Data = Data> {
+export class StateManager<T extends Data> {
     /// The data contained in and managed by this StateManager.
     private _data: T | null = null;
 
@@ -105,7 +105,7 @@ export class StateManager<T extends Data = Data> {
 
     constructor() {}
 
-    ref<U extends Data = Data>(...path: string[]): StateRef<U> {
+    ref<U extends Data>(...path: string[]): StateRef<U> {
         return new StateRef(this, path);
     }
 

--- a/packages/web/src/lib/js/board.ts
+++ b/packages/web/src/lib/js/board.ts
@@ -1,5 +1,5 @@
 import { browser } from '$app/environment';
-import type { Geometry, Grid, Idx, IdxMap, schema } from '@sudoku-studio/schema';
+import type { Geometry, Grid, Idx, IdxBitset, IdxMap, schema } from '@sudoku-studio/schema';
 import type { Data, Diff } from '@sudoku-studio/state-manager/src';
 import { StateManager } from '@sudoku-studio/state-manager/src';
 import { getDigits as getDigitsHelper } from '@sudoku-studio/board-utils/src';
@@ -8,7 +8,7 @@ import { writable } from 'svelte/store';
 export const boardSvg = writable<SVGSVGElement>();
 export const boardDiv = writable<HTMLDivElement>();
 
-export const boardState = new StateManager();
+export const boardState = new StateManager<schema.Board>();
 if (browser) {
     (window as any).boardState = boardState;
 }
@@ -54,7 +54,7 @@ export function setCellValue(markType: string, cellIndex: Idx<Geometry.CELL>, ne
     return elementRef.replace(newValue);
 }
 
-export const warningState = new StateManager();
+export const warningState = new StateManager<IdxBitset<Geometry.CELL>>();
 if (browser) {
     (window as any).warningState = warningState;
 }

--- a/packages/web/src/lib/js/element/arrow.ts
+++ b/packages/web/src/lib/js/element/arrow.ts
@@ -103,7 +103,7 @@ export function getArrowInputHandler(
     }
 
     let mode: Mode = Mode.DYNAMIC;
-    let arrowRef: null | StateRef = null;
+    let arrowRef: null | StateRef<schema.ArrowElementItem> = null;
     let bulbCells: Idx<Geometry.CELL>[] = [];
     let bodyCells: Idx<Geometry.CELL>[] = [];
 

--- a/packages/web/src/lib/js/elementStores.ts
+++ b/packages/web/src/lib/js/elementStores.ts
@@ -11,7 +11,7 @@ import { boardRepr, buildRegionMap, getDigits } from '@sudoku-studio/board-utils
 
 export type ElementHandlerItem = {
     id: string;
-    elementRef: StateRef;
+    elementRef: StateRef<any>;
     info: ElementInfo<unknown>;
     type: schema.ElementType;
 };

--- a/packages/web/src/lib/js/input/lineInputHandler.ts
+++ b/packages/web/src/lib/js/input/lineInputHandler.ts
@@ -23,7 +23,7 @@ export function getLineInputHandler(
 
     const pointerHandler = new AdjacentCellPointerHandler(true);
 
-    let lineRef: null | StateRef = null;
+    let lineRef: null | StateRef<schema.LineElementItem> = null;
     const lineCells: Idx<Geometry.CELL>[] = [];
 
     function handle(event: CellDragTapEvent) {

--- a/packages/web/src/lib/svelte/board/BoardContainer.svelte
+++ b/packages/web/src/lib/svelte/board/BoardContainer.svelte
@@ -5,6 +5,7 @@
     import { currentInputHandler } from '$lib/js/elementStores';
     import type { InputHandler } from '$lib/js/input/inputHandler';
     import { userState } from '$lib/js/user';
+    import type { schema } from '@sudoku-studio/schema';
 
     function wrapListener(inputHandler: null | InputHandler, key: keyof InputHandler): (event: any) => void {
         return (event) => {
@@ -16,7 +17,7 @@
         };
     }
 
-    export let boardState: StateManager;
+    export let boardState: StateManager<schema.Board>;
 </script>
 
 <svelte:window

--- a/packages/web/src/lib/svelte/edit/constraint/CheckboxMenuComponent.svelte
+++ b/packages/web/src/lib/svelte/edit/constraint/CheckboxMenuComponent.svelte
@@ -7,7 +7,7 @@
     import { removeElement } from '$lib/js/elementStores';
 
     export let id: string;
-    export let elementRef: StateRef;
+    export let elementRef: StateRef<{ value?: boolean | Record<string, boolean> }>;
     export let info: CheckboxMenuComponent;
     export let deletable: boolean;
 

--- a/packages/web/src/lib/svelte/edit/constraint/SelectMenuComponent.svelte
+++ b/packages/web/src/lib/svelte/edit/constraint/SelectMenuComponent.svelte
@@ -6,11 +6,10 @@
     import ConstraintRow from './ConstraintRow.svelte';
 
     export let id: string;
-    export let elementRef: StateRef;
+    export let elementRef: StateRef<any>;
     export let info: SelectMenuComponent;
     export let deletable: boolean;
 
-    // @ts-ignore
     const _unused = elementRef;
 </script>
 

--- a/packages/web/src/lib/svelte/entry/DigitButton.svelte
+++ b/packages/web/src/lib/svelte/entry/DigitButton.svelte
@@ -32,7 +32,7 @@
 </button>
 
 <style lang="scss">
-    @use '../../css/padbutton';
+    @use '$lib/css/padbutton';
 
     .padbutton {
         &.center {

--- a/packages/web/svelte.config.js
+++ b/packages/web/svelte.config.js
@@ -1,6 +1,7 @@
 import adapter from '@sveltejs/adapter-static';
 import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
 import process from 'process';
+import { join } from 'path';
 
 if (null == process.env.SUDOKU_STUDIO_VERSION) {
     process.env.SUDOKU_STUDIO_VERSION = 'dev';
@@ -10,7 +11,16 @@ if (null == process.env.SUDOKU_STUDIO_VERSION) {
 const config = {
     // Consult https://svelte.dev/docs/kit/integrations
     // for more information about preprocessors
-    preprocess: vitePreprocess(),
+    preprocess: vitePreprocess({
+        style: {
+            resolve: {
+                alias: {
+                    // https://github.com/sveltejs/language-tools/issues/1986#issuecomment-2317238374
+                    $lib: join(import.meta.dirname, 'src/lib'),
+                },
+            },
+        },
+    }),
 
     kit: {
         // See https://svelte.dev/docs/kit/adapters for more information about adapters.


### PR DESCRIPTION
https://svelte.dev/docs/svelte/v5-migration-guide#Reactivity-syntax-changes-export-let-$props

One step closer to modular board elements