### PR TITLE
refactor: round path of selection instead of guassian blur, fix #46

### DIFF
--- a/packages/board-utils/package.json
+++ b/packages/board-utils/package.json
@@ -14,12 +14,13 @@
     "scripts": {
         "clean": "rm -rf dist node_modules",
         "build": "tsc",
-        "check": "tsc --noEmit"
-    },
-    "dependencies": {
-        "@sudoku-studio/schema": "workspace:*"
+        "check": "tsc --noEmit",
+        "test": "vitest",
+        "test:unit": "vitest"
     },
     "devDependencies": {
-        "typescript": "^5.0.0"
+        "@sudoku-studio/schema": "workspace:*",
+        "typescript": "^5.0.0",
+        "vitest": "^3.1.2"
     }
 }

--- a/packages/board-utils/src/board-utils.ts
+++ b/packages/board-utils/src/board-utils.ts
@@ -410,35 +410,46 @@ export function makePath(
     }
 
     if (bezierRounding) {
-        const out = ['M', points[0].join(',')];
-        for (let i = 2; i < points.length; i++) {
-            const a = points[i - 2];
-            const b = points[i - 1];
-            const c = points[i];
-
-            const ba = [a[0] - b[0], a[1] - b[1]] as [number, number];
-            const bc = [c[0] - b[0], c[1] - b[1]] as [number, number];
-            normalize2d(ba);
-            normalize2d(bc);
-
-            ba[0] *= bezierRounding;
-            ba[1] *= bezierRounding;
-            bc[0] *= bezierRounding;
-            bc[1] *= bezierRounding;
-
-            ba[0] += b[0];
-            ba[1] += b[1];
-            bc[0] += b[0];
-            bc[1] += b[1];
-
-            out.push('L', ba.join(','), 'Q', b.join(','), ' ', bc.join(','));
-        }
-        out.push('L', points[points.length - 1].join(','));
-
-        return out.join('');
+        return pathBezierRounding(points, bezierRounding, false);
     }
 
     return 'M' + points.map((xy) => xy.join(',')).join('L');
+}
+
+export function pathBezierRounding(points: [number, number][], bezierRounding: number, loop: boolean): string {
+    const out = loop ? [] : ['M', points[0].join(',')];
+    // Don't round the first and last points if not looping.
+    const len = loop ? points.length : points.length - 2;
+    for (let i = 0; i < len; i++) {
+        const a = points[i];
+        const b = points[(i + 1) % points.length];
+        const c = points[(i + 2) % points.length];
+
+        const ba = [a[0] - b[0], a[1] - b[1]] as [number, number];
+        const bc = [c[0] - b[0], c[1] - b[1]] as [number, number];
+        normalize2d(ba);
+        normalize2d(bc);
+
+        ba[0] *= bezierRounding;
+        ba[1] *= bezierRounding;
+        bc[0] *= bezierRounding;
+        bc[1] *= bezierRounding;
+
+        ba[0] += b[0];
+        ba[1] += b[1];
+        bc[0] += b[0];
+        bc[1] += b[1];
+
+        out.push('L', ba.join(','), 'Q', b.join(','), ' ', bc.join(','));
+    }
+    if (loop) {
+        out.push('Z');
+    } else {
+        out.push('L', points[points.length - 1].join(','));
+    }
+    out[0] = 'M'; // Overwrite first `L` in the `loop` case.
+
+    return out.join('');
 }
 
 export function normalize2d(vec: [number, number]): void {
@@ -547,17 +558,24 @@ export function getBorderAdjList(
     return adjList;
 }
 
+export type GetBorderPathOptions = {
+    // Amount to inset the outline.
+    inset?: number;
+    // If true, diagonally connect touching corners.
+    connectDiag?: boolean;
+    // If true, round the corners.
+    bezierRounding?: number;
+};
 /**
  * @param cellIdxes Cell indexes (0 to 80 for 9x9).
  * @param grid Grid width and height.
- * @param inset (Optional) Amount to inset the outline.
- * @returns SVG <path d="..." /> string.
+ * @param options Special options, see GetBorderPathOptions.
+ * @returns `d` string for SVG `<path d="..." />`.
  */
 export function getBorderPath(
     cellIdxes: Idx<Geometry.CELL>[],
     grid: Grid,
-    inset = 0,
-    connectDiag = false,
+    { inset = 0, connectDiag = false, bezierRounding = 0 }: GetBorderPathOptions = {},
 ): string | null {
     const adjList = getBorderAdjList(cellIdxes, grid);
     if (0 >= adjList.size) return null;
@@ -579,7 +597,7 @@ export function getBorderPath(
         let b = cornerIdx2cornerCoord(secondVertId, grid);
         let vertId = secondVertId;
 
-        const points: string[] = [];
+        const points: [number, number][] = [];
         do {
             // Find all the next edges.
             const adj = adjList.get(vertId)!;
@@ -616,10 +634,10 @@ export function getBorderPath(
                 x += dx;
                 y += dy;
                 if (connectedDiags.has(vertId)) {
-                    points.push(`${x - 3 * ax},${y - 3 * ay}`);
-                    points.push(`${x - 3 * bx},${y - 3 * by}`);
+                    points.push([x - 3 * ax, y - 3 * ay]);
+                    points.push([x - 3 * bx, y - 3 * by]);
                 } else {
-                    points.push(`${x},${y}`);
+                    points.push([x, y]);
                 }
             }
 
@@ -629,7 +647,11 @@ export function getBorderPath(
             vertId = nextVertId;
         } while (secondVertId !== vertId);
 
-        loops.push('M' + points.join('L') + 'Z');
+        loops.push(
+            bezierRounding
+                ? pathBezierRounding(points, bezierRounding, true)
+                : 'M' + points.map(([x, y]) => `${x},${y}`).join('L') + 'Z',
+        );
     }
     return loops.join('');
 }

--- a/packages/board-utils/src/board-utils.ts
+++ b/packages/board-utils/src/board-utils.ts
@@ -431,11 +431,11 @@ export function makePath(
             bc[0] += b[0];
             bc[1] += b[1];
 
-            out.push('L', ba.join(','), 'Q', b.join(','), bc.join(','));
+            out.push('L', ba.join(','), 'Q', b.join(','), ' ', bc.join(','));
         }
         out.push('L', points[points.length - 1].join(','));
 
-        return out.join(' ');
+        return out.join('');
     }
 
     return 'M' + points.map((xy) => xy.join(',')).join('L');

--- a/packages/board-utils/test/paths.test.ts
+++ b/packages/board-utils/test/paths.test.ts
@@ -22,7 +22,7 @@ describe('makePath', () => {
         );
         expect(path).toBe('M0.5,0.5L1.5,1.5L1.5,2.5L2.5,1.5L3.5,1.5L3.5,0.5');
     });
-    test('squiggly with options', () => {
+    test('squiggly + options', () => {
         const grid: Grid = { width: 9, height: 9 };
         const path = makePath(
             [
@@ -42,11 +42,25 @@ describe('makePath', () => {
     });
 });
 
-test('getBorderPath', () => {
-    const grid: Grid = { width: 9, height: 9 };
-    const selection: Idx<Geometry.CELL>[] = [0, 1, 3, 7, 8, 9, 10, 12, 13, 14, 15, 17, 20, 21, 23, 27, 29, 31, 34, 35];
-    const path = getBorderPath(selection, grid);
-    expect(path).toBe(
-        'M2,0L2,2L0,2L0,0ZM4,0L4,1L7,1L7,2L6,2L6,3L5,3L5,2L4,2L4,3L3,3L3,4L2,4L2,2L3,2L3,0ZM9,0L9,2L8,2L8,1L7,1L7,0ZM5,3L5,4L4,4L4,3ZM1,3L1,4L0,4L0,3ZM9,3L9,4L7,4L7,3Z',
-    );
+describe('getBorderPath', () => {
+    test('basic', () => {
+        const grid: Grid = { width: 9, height: 9 };
+        const selection: Idx<Geometry.CELL>[] = [
+            0, 1, 3, 7, 8, 9, 10, 12, 13, 14, 15, 17, 20, 21, 23, 27, 29, 31, 34, 35,
+        ];
+        const path = getBorderPath(selection, grid);
+        expect(path).toBe(
+            'M2,0L2,2L0,2L0,0ZM4,0L4,1L7,1L7,2L6,2L6,3L5,3L5,2L4,2L4,3L3,3L3,4L2,4L2,2L3,2L3,0ZM9,0L9,2L8,2L8,1L7,1L7,0ZM5,3L5,4L4,4L4,3ZM1,3L1,4L0,4L0,3ZM9,3L9,4L7,4L7,3Z',
+        );
+    });
+    test('bezierRounding', () => {
+        const grid: Grid = { width: 9, height: 9 };
+        const selection: Idx<Geometry.CELL>[] = [
+            0, 1, 3, 7, 8, 9, 10, 12, 13, 14, 15, 17, 20, 21, 23, 27, 29, 31, 34, 35,
+        ];
+        const path = getBorderPath(selection, grid, { bezierRounding: 0.1 });
+        expect(path).toBe(
+            'M2,1.9Q2,2 1.9,2L0.1,2Q0,2 0,1.9L0,0.1Q0,0 0.1,0L1.9,0Q2,0 2,0.1ZM4,0.9Q4,1 4.1,1L6.9,1Q7,1 7,1.1L7,1.9Q7,2 6.9,2L6.1,2Q6,2 6,2.1L6,2.9Q6,3 5.9,3L5.1,3Q5,3 5,2.9L5,2.1Q5,2 4.9,2L4.1,2Q4,2 4,2.1L4,2.9Q4,3 3.9,3L3.1,3Q3,3 3,3.1L3,3.9Q3,4 2.9,4L2.1,4Q2,4 2,3.9L2,2.1Q2,2 2.1,2L2.9,2Q3,2 3,1.9L3,0.1Q3,0 3.1,0L3.9,0Q4,0 4,0.1ZM9,1.9Q9,2 8.9,2L8.1,2Q8,2 8,1.9L8,1.1Q8,1 7.9,1L7.1,1Q7,1 7,0.9L7,0.1Q7,0 7.1,0L8.9,0Q9,0 9,0.1ZM5,3.9Q5,4 4.9,4L4.1,4Q4,4 4,3.9L4,3.1Q4,3 4.1,3L4.9,3Q5,3 5,3.1ZM1,3.9Q1,4 0.9,4L0.1,4Q0,4 0,3.9L0,3.1Q0,3 0.1,3L0.9,3Q1,3 1,3.1ZM9,3.9Q9,4 8.9,4L7.1,4Q7,4 7,3.9L7,3.1Q7,3 7.1,3L8.9,3Q9,3 9,3.1Z',
+        );
+    });
 });

--- a/packages/board-utils/test/paths.test.ts
+++ b/packages/board-utils/test/paths.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from 'vitest';
+import { cellCoord2CellIdx, getBorderPath, makePath } from '@sudoku-studio/board-utils/src';
+import type { Coord, Geometry, Grid, Idx } from '@sudoku-studio/schema';
+
+describe('makePath', () => {
+    test('basic', () => {
+        const path = makePath([0, 1, 2, 3], { width: 4, height: 4 });
+        expect(path).toBe('M0.5,0.5L1.5,0.5L2.5,0.5L3.5,0.5');
+    });
+    test('squiggly', () => {
+        const grid: Grid = { width: 9, height: 9 };
+        const path = makePath(
+            [
+                [0, 0],
+                [1, 1],
+                [1, 2],
+                [2, 1],
+                [3, 1],
+                [3, 0],
+            ].map((coord) => cellCoord2CellIdx(coord as Coord<Geometry.CELL>, grid)),
+            grid,
+        );
+        expect(path).toBe('M0.5,0.5L1.5,1.5L1.5,2.5L2.5,1.5L3.5,1.5L3.5,0.5');
+    });
+    test('squiggly with options', () => {
+        const grid: Grid = { width: 9, height: 9 };
+        const path = makePath(
+            [
+                [0, 0],
+                [1, 1],
+                [1, 2],
+                [2, 1],
+                [3, 1],
+                [3, 0],
+            ].map((coord) => cellCoord2CellIdx(coord as Coord<Geometry.CELL>, grid)),
+            grid,
+            { shortenHead: 0.05, shortenTail: 0.15, bezierRounding: 0.1 },
+        );
+        expect(path).toBe(
+            'M0.5353553390593274,0.5353553390593274L1.4292893218813452,1.4292893218813452Q1.5,1.5 1.5,1.6L1.5,2.4Q1.5,2.5 1.5707106781186548,2.4292893218813454L2.4292893218813454,1.5707106781186548Q2.5,1.5 2.6,1.5L3.4,1.5Q3.5,1.5 3.5,1.4L3.5,0.65',
+        );
+    });
+});
+
+test('getBorderPath', () => {
+    const grid: Grid = { width: 9, height: 9 };
+    const selection: Idx<Geometry.CELL>[] = [0, 1, 3, 7, 8, 9, 10, 12, 13, 14, 15, 17, 20, 21, 23, 27, 29, 31, 34, 35];
+    const path = getBorderPath(selection, grid);
+    expect(path).toBe(
+        'M2,0L2,2L0,2L0,0ZM4,0L4,1L7,1L7,2L6,2L6,3L5,3L5,2L4,2L4,3L3,3L3,4L2,4L2,2L3,2L3,0ZM9,0L9,2L8,2L8,1L7,1L7,0ZM5,3L5,4L4,4L4,3ZM1,3L1,4L0,4L0,3ZM9,3L9,4L7,4L7,3Z',
+    );
+});

--- a/packages/board-utils/vitest.config.ts
+++ b/packages/board-utils/vitest.config.ts
@@ -1,0 +1,3 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({ test: { isolate: false } });

--- a/packages/board/src/lib/Board.svelte
+++ b/packages/board/src/lib/Board.svelte
@@ -279,12 +279,12 @@
     const givensMaskPath = derived(
         [elementsRef, grid],
         ([elements, grid]) =>
-            getBorderPath(idxMapToKeysArray(getDigits(elements || {}, true, false)), grid!, 0) || undefined,
+            getBorderPath(idxMapToKeysArray(getDigits(elements || {}, true, false)), grid!) || undefined,
     );
     const givensFilledMaskPath = derived(
         [elementsRef, grid],
         ([elements, grid]) =>
-            getBorderPath(idxMapToKeysArray(getDigits(elements || {}, true, true)), grid!, 0) || undefined,
+            getBorderPath(idxMapToKeysArray(getDigits(elements || {}, true, true)), grid!) || undefined,
     );
 
     type ElementList<T extends keyof typeof ELEMENT_RENDERERS = any> = {

--- a/packages/board/src/lib/svelte/CloneRender.svelte
+++ b/packages/board/src/lib/svelte/CloneRender.svelte
@@ -20,7 +20,7 @@
                 cellsArr.sort((a, b) => a - b);
                 if (0 >= cellsArr.length) continue;
                 const lastIdx = cellsArr[cellsArr.length - 1];
-                const d = getBorderPath(cellsArr, grid, inset, true);
+                const d = getBorderPath(cellsArr, grid, { inset, connectDiag: true });
                 if (null == d) continue;
                 const lastCoord = cellIdx2cellCoord(lastIdx, grid);
                 const labelPos = {

--- a/packages/board/src/lib/svelte/GridRegionRender.svelte
+++ b/packages/board/src/lib/svelte/GridRegionRender.svelte
@@ -13,7 +13,7 @@
 
 <g {id}>
     {#each arrayObj2array($ref || {}) as region, i (i)}
-        {@const d = getBorderPath(idxMapToKeysArray(region), grid, 0, false)}
+        {@const d = getBorderPath(idxMapToKeysArray(region), grid)}
         {#if d != null && 0 < d.length}
             <path {d} fill="none" stroke="#000" stroke-width={GRID_REGION_THICKNESS} />
         {/if}

--- a/packages/board/src/lib/svelte/KillerRender.svelte
+++ b/packages/board/src/lib/svelte/KillerRender.svelte
@@ -16,7 +16,7 @@
             const cellsArr = idxMapToKeysArray<Geometry.CELL>(cells);
             if (0 >= cellsArr.length) continue;
             const firstIdx = cellsArr[0];
-            const d = getBorderPath(cellsArr, grid, inset, true);
+            const d = getBorderPath(cellsArr, grid, { inset, connectDiag: true });
             if (null == d) continue;
             const firstCoord = cellIdx2cellCoord(firstIdx, grid);
             const labelPos = { x: firstCoord[0] + inset - strokeWidth, y: firstCoord[1] + inset - strokeWidth };

--- a/packages/board/src/lib/svelte/SelectRender.svelte
+++ b/packages/board/src/lib/svelte/SelectRender.svelte
@@ -20,23 +20,14 @@
     } = $props();
 
     const inset = 0.075;
-    const innerRadius = 0.05;
+    const bezierRounding = 0.125;
 
-    const dMask = $derived(getBorderPath(idxMapToKeysArray($ref), grid, inset) || undefined);
-    const dFill = $derived(getBorderPath(idxMapToKeysArray($ref), grid, 0) || undefined);
+    const dMask = $derived(getBorderPath(idxMapToKeysArray($ref), grid, { inset, bezierRounding }) || undefined);
+    const dFill = $derived(getBorderPath(idxMapToKeysArray($ref), grid) || undefined);
 </script>
 
-<filter id="select-{id}-blur">
-    <feGaussianBlur in="SourceGraphic" stdDeviation={innerRadius} />
-    <feComponentTransfer>
-        <feFuncR type="identity" />
-        <feFuncG type="identity" />
-        <feFuncB type="identity" />
-        <feFuncA type="linear" slope="20" intercept="-9.5" />
-    </feComponentTransfer>
-</filter>
 <mask id="select-{id}-mask" maskUnits="userSpaceOnUse" x="0" y="0" width={grid.width} height={grid.height}>
     <rect x="0" y="0" width={grid.width} height={grid.height} fill={outlineOpacity} />
-    <path d={dMask} fill={innerOpacity} stroke="none" filter="url(#select-{id}-blur)" />
+    <path d={dMask} fill={innerOpacity} stroke="none" />
 </mask>
 <path {id} d={dFill} {fill} stroke="none" mask="url(#select-{id}-mask)" />

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,14 +87,16 @@ importers:
   packages/board-svg: {}
 
   packages/board-utils:
-    dependencies:
+    devDependencies:
       '@sudoku-studio/schema':
         specifier: workspace:*
         version: link:../schema
-    devDependencies:
       typescript:
         specifier: ^5.0.0
         version: 5.8.3
+      vitest:
+        specifier: ^3.1.2
+        version: 3.1.2(@types/node@22.15.15)(sass-embedded@1.87.0)(sass@1.87.0)
 
   packages/schema: {}
 


### PR DESCRIPTION
Previous selection code used a mask and gaussian blur to round corners, now we just round the path directly for better performance, to fix #46.

Adds tests for `makePath`, `getBorderPath` in `board-utils`.
